### PR TITLE
Harden modular Paddle payment adapter

### DIFF
--- a/modules/billing-billing-core/src/Actions/TransitionBillingAccount.php
+++ b/modules/billing-billing-core/src/Actions/TransitionBillingAccount.php
@@ -20,9 +20,14 @@ final readonly class TransitionBillingAccount
         }
 
         return $this->database->transaction(function () use ($account, $status): BillingAccount {
-            $account->update(['status' => $status]);
+            $locked = BillingAccount::query()->lockForUpdate()->findOrFail($account->getKey());
+            if ($locked->status === BillingAccountStatus::Closed && $status !== BillingAccountStatus::Closed) {
+                throw new InvalidArgumentException('A closed billing account cannot be reopened.');
+            }
 
-            return $account->refresh();
+            $locked->update(['status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/billing-billing-core/src/Actions/UpdateBillingAccount.php
+++ b/modules/billing-billing-core/src/Actions/UpdateBillingAccount.php
@@ -15,15 +15,16 @@ final readonly class UpdateBillingAccount
     public function execute(BillingAccount $account, array $attributes): BillingAccount
     {
         return $this->database->transaction(function () use ($account, $attributes): BillingAccount {
+            $locked = BillingAccount::query()->lockForUpdate()->findOrFail($account->getKey());
             if (array_key_exists('name', $attributes)) {
                 $attributes['name'] = trim((string) $attributes['name']);
             }
             if (array_key_exists('currency', $attributes)) {
                 $attributes['currency'] = strtoupper((string) $attributes['currency']);
             }
-            $account->fill($attributes)->save();
+            $locked->fill($attributes)->save();
 
-            return $account->refresh();
+            return $locked->refresh();
         });
     }
 }

--- a/modules/billing-billing-core/src/Actions/UpdateBillingRecord.php
+++ b/modules/billing-billing-core/src/Actions/UpdateBillingRecord.php
@@ -15,10 +15,11 @@ final readonly class UpdateBillingRecord
     public function execute(Model $record, array $attributes): Model
     {
         return $this->database->transaction(function () use ($record, $attributes): Model {
-            $record->fill($attributes);
-            $record->save();
+            $locked = $record->newQuery()->lockForUpdate()->findOrFail($record->getKey());
+            $locked->fill($attributes);
+            $locked->save();
 
-            return $record->refresh();
+            return $locked->refresh();
         });
     }
 }

--- a/modules/billing-catalog/src/Actions/TransitionCatalogLifecycle.php
+++ b/modules/billing-catalog/src/Actions/TransitionCatalogLifecycle.php
@@ -15,18 +15,19 @@ final readonly class TransitionCatalogLifecycle
 
     public function execute(CatalogRecord $record, CatalogStatus $status): CatalogRecord
     {
-        $current = $record->status;
-        if ($current === CatalogStatus::Archived && $status !== CatalogStatus::Archived) {
-            throw ValidationException::withMessages(['status' => 'Archived catalog records cannot be reactivated.']);
-        }
-        if ($current === CatalogStatus::Draft && $status === CatalogStatus::Archived) {
-            throw ValidationException::withMessages(['status' => 'A draft must be activated before it can be archived.']);
-        }
-
         return $this->database->transaction(function () use ($record, $status): CatalogRecord {
-            $record->update(['status' => $status]);
+            $locked = $record::query()->lockForUpdate()->findOrFail($record->getKey());
+            $current = $locked->status;
+            if ($current === CatalogStatus::Archived && $status !== CatalogStatus::Archived) {
+                throw ValidationException::withMessages(['status' => 'Archived catalog records cannot be reactivated.']);
+            }
+            if ($current === CatalogStatus::Draft && $status === CatalogStatus::Archived) {
+                throw ValidationException::withMessages(['status' => 'A draft must be activated before it can be archived.']);
+            }
 
-            return $record->refresh();
+            $locked->update(['status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/billing-catalog/src/Actions/TransitionProductLifecycle.php
+++ b/modules/billing-catalog/src/Actions/TransitionProductLifecycle.php
@@ -18,9 +18,14 @@ final class TransitionProductLifecycle
         }
 
         return DB::transaction(function () use ($product, $status): Product {
-            $product->update(['status' => $status]);
+            $locked = Product::query()->lockForUpdate()->findOrFail($product->getKey());
+            if ($locked->status === ProductStatus::Archived && $status !== ProductStatus::Archived) {
+                throw new InvalidArgumentException('An archived product cannot be reopened.');
+            }
 
-            return $product->refresh();
+            $locked->update(['status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/billing-orders-api/src/Http/Controllers/OrderController.php
+++ b/modules/billing-orders-api/src/Http/Controllers/OrderController.php
@@ -72,6 +72,7 @@ final class OrderController extends Controller
 
     public function fraud(Request $request, Order $order, ReviewFraud $review): JsonResponse
     {
+        $order = $this->forCurrentTeam($request, $order);
         Gate::authorize('update', $order);
         $data = $request->validate(['fraud_status' => ['required', 'in:pending,cleared,blocked,not_required']]);
 
@@ -80,6 +81,7 @@ final class OrderController extends Controller
 
     public function change(Request $request, Order $order, AddChangeOrder $add): JsonResponse
     {
+        $order = $this->forCurrentTeam($request, $order);
         Gate::authorize('update', $order);
         $data = $request->validate(['reason' => ['required', 'string', 'max:1000'], 'items' => ['sometimes', 'array'], 'amount_minor' => ['sometimes', 'integer', 'min:0']]);
 
@@ -96,5 +98,10 @@ final class OrderController extends Controller
         $team = data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id');
 
         return $team === null ? null : (int) $team;
+    }
+
+    private function forCurrentTeam(Request $request, Order $order): Order
+    {
+        return Order::query()->whereKey($order->getKey())->where('team_id', $this->team($request))->firstOrFail();
     }
 }

--- a/modules/billing-orders-api/src/Http/Controllers/OrderController.php
+++ b/modules/billing-orders-api/src/Http/Controllers/OrderController.php
@@ -61,6 +61,10 @@ final class OrderController extends Controller
     public function checkout(Request $request, Cart $cart, CheckoutCart $checkout): JsonResponse
     {
         Gate::authorize('create', Order::class);
+        $cart = Cart::query()
+            ->whereKey($cart->getKey())
+            ->where('team_id', $this->team($request))
+            ->firstOrFail();
         $data = $request->validate(['subtotal_minor' => ['required', 'integer', 'min:0'], 'discount_minor' => ['sometimes', 'integer', 'min:0'], 'tax_minor' => ['sometimes', 'integer', 'min:0'], 'fraud_review_required' => ['sometimes', 'boolean'], 'agreement' => ['nullable', 'array']]);
 
         return response()->json(['data' => $this->resource($checkout->execute($cart, $data))], 201);

--- a/modules/billing-orders/src/Actions/AddChangeOrder.php
+++ b/modules/billing-orders/src/Actions/AddChangeOrder.php
@@ -19,11 +19,12 @@ final readonly class AddChangeOrder
         }
 
         return $this->database->transaction(function () use ($order, $change): Order {
-            $changes = $order->change_orders ?? [];
+            $locked = Order::query()->lockForUpdate()->findOrFail($order->getKey());
+            $changes = $locked->change_orders ?? [];
             $changes[] = [...$change, 'created_at' => now()->toIso8601String()];
-            $order->update(['change_orders' => $changes]);
+            $locked->update(['change_orders' => $changes]);
 
-            return $order->refresh();
+            return $locked->refresh();
         });
     }
 }

--- a/modules/billing-orders/src/Actions/CheckoutCart.php
+++ b/modules/billing-orders/src/Actions/CheckoutCart.php
@@ -19,8 +19,13 @@ final readonly class CheckoutCart
         }
 
         return $this->database->transaction(function () use ($cart, $attributes): Order {
-            $order = $this->createOrder->execute([...$attributes, 'team_id' => $cart->team_id, 'customer_id' => $cart->customer_id, 'currency' => $cart->currency]);
-            $cart->update(['status' => 'checked_out']);
+            $locked = Cart::query()->lockForUpdate()->findOrFail($cart->getKey());
+            if ($locked->status !== 'open' || ($locked->expires_at !== null && $locked->expires_at->isPast())) {
+                throw new \LogicException('Only open, non-expired carts can be checked out.');
+            }
+
+            $order = $this->createOrder->execute([...$attributes, 'team_id' => $locked->team_id, 'customer_id' => $locked->customer_id, 'currency' => $locked->currency]);
+            $locked->update(['status' => 'checked_out']);
 
             return $order;
         });

--- a/modules/billing-orders/src/Actions/CreateCart.php
+++ b/modules/billing-orders/src/Actions/CreateCart.php
@@ -6,6 +6,7 @@ namespace Liberu\Billing\Orders\Actions;
 
 use Illuminate\Support\Facades\DB;
 use Liberu\Billing\Orders\Models\Cart;
+use Liberu\Billing\Orders\Support\CustomerReference;
 
 final class CreateCart
 {
@@ -16,6 +17,9 @@ final class CreateCart
             throw new \InvalidArgumentException('A cart must contain items.');
         }
 
-        return DB::transaction(fn (): Cart => Cart::query()->create(['team_id' => $attributes['team_id'] ?? null, 'customer_id' => $attributes['customer_id'] ?? null, 'currency' => strtoupper($attributes['currency']), 'items' => $attributes['items'], 'expires_at' => $attributes['expires_at'] ?? null, 'status' => 'open']));
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam(app('db'), $attributes['customer_id'] ?? null, $teamId);
+
+        return DB::transaction(fn (): Cart => Cart::query()->create(['team_id' => $teamId, 'customer_id' => $customerId, 'currency' => strtoupper($attributes['currency']), 'items' => $attributes['items'], 'expires_at' => $attributes['expires_at'] ?? null, 'status' => 'open']));
     }
 }

--- a/modules/billing-orders/src/Actions/CreateOrder.php
+++ b/modules/billing-orders/src/Actions/CreateOrder.php
@@ -8,6 +8,7 @@ use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Orders\Enums\FraudReviewStatus;
 use Liberu\Billing\Orders\Enums\OrderStatus;
 use Liberu\Billing\Orders\Models\Order;
+use Liberu\Billing\Orders\Models\Quote;
 
 final readonly class CreateOrder
 {
@@ -22,8 +23,13 @@ final readonly class CreateOrder
         if ($subtotal < 0 || $discount < 0 || $tax < 0 || $discount > $subtotal) {
             throw new \InvalidArgumentException('Order amounts are invalid.');
         }
+        $teamId = $attributes['team_id'] ?? null;
+        $quoteId = $attributes['quote_id'] ?? null;
+        if ($quoteId !== null && ! Quote::query()->whereKey((int) $quoteId)->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $teamId))->exists()) {
+            throw new \InvalidArgumentException('Order quote reference is invalid.');
+        }
         $review = (bool) ($attributes['fraud_review_required'] ?? false);
 
-        return $this->database->transaction(fn (): Order => Order::query()->create(['team_id' => $attributes['team_id'] ?? null, 'customer_id' => $attributes['customer_id'] ?? null, 'quote_id' => $attributes['quote_id'] ?? null, 'order_number' => $attributes['order_number'] ?? ('ORD-'.strtoupper(bin2hex(random_bytes(5)))), 'currency' => strtoupper((string) $attributes['currency']), 'subtotal_minor' => $subtotal, 'discount_minor' => $discount, 'tax_minor' => $tax, 'total_minor' => $subtotal - $discount + $tax, 'status' => $review ? OrderStatus::PendingReview : OrderStatus::Approved, 'fraud_status' => $review ? FraudReviewStatus::Pending : FraudReviewStatus::NotRequired, 'agreement' => $attributes['agreement'] ?? null, 'change_orders' => [], 'metadata' => $attributes['metadata'] ?? []]));
+        return $this->database->transaction(fn (): Order => Order::query()->create(['team_id' => $teamId, 'customer_id' => $attributes['customer_id'] ?? null, 'quote_id' => $quoteId, 'order_number' => $attributes['order_number'] ?? ('ORD-'.strtoupper(bin2hex(random_bytes(5)))), 'currency' => strtoupper((string) $attributes['currency']), 'subtotal_minor' => $subtotal, 'discount_minor' => $discount, 'tax_minor' => $tax, 'total_minor' => $subtotal - $discount + $tax, 'status' => $review ? OrderStatus::PendingReview : OrderStatus::Approved, 'fraud_status' => $review ? FraudReviewStatus::Pending : FraudReviewStatus::NotRequired, 'agreement' => $attributes['agreement'] ?? null, 'change_orders' => [], 'metadata' => $attributes['metadata'] ?? []]));
     }
 }

--- a/modules/billing-orders/src/Actions/CreateOrder.php
+++ b/modules/billing-orders/src/Actions/CreateOrder.php
@@ -9,6 +9,7 @@ use Liberu\Billing\Orders\Enums\FraudReviewStatus;
 use Liberu\Billing\Orders\Enums\OrderStatus;
 use Liberu\Billing\Orders\Models\Order;
 use Liberu\Billing\Orders\Models\Quote;
+use Liberu\Billing\Orders\Support\CustomerReference;
 
 final readonly class CreateOrder
 {
@@ -24,12 +25,13 @@ final readonly class CreateOrder
             throw new \InvalidArgumentException('Order amounts are invalid.');
         }
         $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
         $quoteId = $attributes['quote_id'] ?? null;
         if ($quoteId !== null && ! Quote::query()->whereKey((int) $quoteId)->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $teamId))->exists()) {
             throw new \InvalidArgumentException('Order quote reference is invalid.');
         }
         $review = (bool) ($attributes['fraud_review_required'] ?? false);
 
-        return $this->database->transaction(fn (): Order => Order::query()->create(['team_id' => $teamId, 'customer_id' => $attributes['customer_id'] ?? null, 'quote_id' => $quoteId, 'order_number' => $attributes['order_number'] ?? ('ORD-'.strtoupper(bin2hex(random_bytes(5)))), 'currency' => strtoupper((string) $attributes['currency']), 'subtotal_minor' => $subtotal, 'discount_minor' => $discount, 'tax_minor' => $tax, 'total_minor' => $subtotal - $discount + $tax, 'status' => $review ? OrderStatus::PendingReview : OrderStatus::Approved, 'fraud_status' => $review ? FraudReviewStatus::Pending : FraudReviewStatus::NotRequired, 'agreement' => $attributes['agreement'] ?? null, 'change_orders' => [], 'metadata' => $attributes['metadata'] ?? []]));
+        return $this->database->transaction(fn (): Order => Order::query()->create(['team_id' => $teamId, 'customer_id' => $customerId, 'quote_id' => $quoteId, 'order_number' => $attributes['order_number'] ?? ('ORD-'.strtoupper(bin2hex(random_bytes(5)))), 'currency' => strtoupper((string) $attributes['currency']), 'subtotal_minor' => $subtotal, 'discount_minor' => $discount, 'tax_minor' => $tax, 'total_minor' => $subtotal - $discount + $tax, 'status' => $review ? OrderStatus::PendingReview : OrderStatus::Approved, 'fraud_status' => $review ? FraudReviewStatus::Pending : FraudReviewStatus::NotRequired, 'agreement' => $attributes['agreement'] ?? null, 'change_orders' => [], 'metadata' => $attributes['metadata'] ?? []]));
     }
 }

--- a/modules/billing-orders/src/Actions/CreateQuote.php
+++ b/modules/billing-orders/src/Actions/CreateQuote.php
@@ -6,6 +6,7 @@ namespace Liberu\Billing\Orders\Actions;
 
 use Illuminate\Support\Facades\DB;
 use Liberu\Billing\Orders\Models\Quote;
+use Liberu\Billing\Orders\Support\CustomerReference;
 
 final class CreateQuote
 {
@@ -17,6 +18,9 @@ final class CreateQuote
             throw new \InvalidArgumentException('Quote total and items are invalid.');
         }
 
-        return DB::transaction(fn (): Quote => Quote::query()->create(['team_id' => $attributes['team_id'] ?? null, 'customer_id' => $attributes['customer_id'] ?? null, 'quote_number' => $attributes['quote_number'] ?? 'QUO-'.strtoupper(bin2hex(random_bytes(5))), 'currency' => strtoupper($attributes['currency']), 'total_minor' => $total, 'items' => $attributes['items'], 'valid_until' => $attributes['valid_until'] ?? null, 'status' => 'draft']));
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam(app('db'), $attributes['customer_id'] ?? null, $teamId);
+
+        return DB::transaction(fn (): Quote => Quote::query()->create(['team_id' => $teamId, 'customer_id' => $customerId, 'quote_number' => $attributes['quote_number'] ?? 'QUO-'.strtoupper(bin2hex(random_bytes(5))), 'currency' => strtoupper($attributes['currency']), 'total_minor' => $total, 'items' => $attributes['items'], 'valid_until' => $attributes['valid_until'] ?? null, 'status' => 'draft']));
     }
 }

--- a/modules/billing-orders/src/Actions/ReviewFraud.php
+++ b/modules/billing-orders/src/Actions/ReviewFraud.php
@@ -6,6 +6,7 @@ namespace Liberu\Billing\Orders\Actions;
 
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Orders\Enums\FraudReviewStatus;
+use Liberu\Billing\Orders\Enums\OrderStatus;
 use Liberu\Billing\Orders\Models\Order;
 
 final readonly class ReviewFraud
@@ -15,9 +16,14 @@ final readonly class ReviewFraud
     public function execute(Order $order, FraudReviewStatus $status): Order
     {
         return $this->database->transaction(function () use ($order, $status): Order {
-            $order->update(['fraud_status' => $status]);
+            $locked = Order::query()->lockForUpdate()->findOrFail($order->getKey());
+            if (in_array($locked->status, [OrderStatus::Completed, OrderStatus::Cancelled], true)) {
+                throw new \LogicException('Terminal orders cannot receive fraud reviews.');
+            }
 
-            return $order->refresh();
+            $locked->update(['fraud_status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/billing-orders/src/Actions/TransitionOrder.php
+++ b/modules/billing-orders/src/Actions/TransitionOrder.php
@@ -23,9 +23,17 @@ final readonly class TransitionOrder
         }
 
         return $this->database->transaction(function () use ($order, $status, $fraudStatus): Order {
-            $order->update(['status' => $status, 'fraud_status' => $fraudStatus ?? $order->fraud_status]);
+            $locked = Order::query()->lockForUpdate()->findOrFail($order->getKey());
+            if ($locked->status === OrderStatus::Completed || $locked->status === OrderStatus::Cancelled) {
+                throw new \LogicException('Terminal orders cannot transition.');
+            }
+            if ($status === OrderStatus::Approved && $locked->fraud_status === FraudReviewStatus::Blocked) {
+                throw new \LogicException('Blocked orders cannot be approved.');
+            }
 
-            return $order->refresh();
+            $locked->update(['status' => $status, 'fraud_status' => $fraudStatus ?? $locked->fraud_status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/billing-orders/src/Support/CustomerReference.php
+++ b/modules/billing-orders/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Orders\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $columns = Schema::hasColumn('customers', 'team_id') ? ['team_id'] : ['id'];
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($columns);
+        if ($customer === null || (Schema::hasColumn('customers', 'team_id') && $customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/modules/billing-pricing-api/src/Http/Controllers/PricingSupportController.php
+++ b/modules/billing-pricing-api/src/Http/Controllers/PricingSupportController.php
@@ -35,13 +35,15 @@ final class PricingSupportController extends Controller
 
     public function redeem(Request $request, PricingDiscount $discount, RedeemPricingDiscount $redeem): JsonResponse
     {
+        $discount = $this->forCurrentTeam($request, PricingDiscount::class, $discount->getKey());
         Gate::authorize('update', $discount);
 
         return response()->json(['data' => $redeem->execute($discount)]);
     }
 
-    public function snapshot(PricingPlan $plan, CapturePricingSnapshot $capture): JsonResponse
+    public function snapshot(Request $request, PricingPlan $plan, CapturePricingSnapshot $capture): JsonResponse
     {
+        $plan = $this->forCurrentTeam($request, PricingPlan::class, $plan->getKey());
         Gate::authorize('update', $plan);
 
         return response()->json(['data' => $capture->execute($plan)], 201);
@@ -64,5 +66,13 @@ final class PricingSupportController extends Controller
     private function team(Request $request): int
     {
         return (int) (data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id'));
+    }
+
+    /** @template TModel of object */
+    private function forCurrentTeam(Request $request, string $model, int $id): object
+    {
+        $teamId = $this->team($request);
+
+        return $model::query()->whereKey($id)->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $teamId))->firstOrFail();
     }
 }

--- a/modules/billing-pricing/CHANGELOG.md
+++ b/modules/billing-pricing/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Validate required fields and model-specific intervals, usage units, and tiers
   at the domain action boundary.
 - Enforce write authorization for pricing mutations and snapshot capture.
+- Added authoritative minor-unit pricing calculation for fixed, usage, and graduated-tier plans.

--- a/modules/billing-pricing/src/Actions/CalculatePricingPlanAmount.php
+++ b/modules/billing-pricing/src/Actions/CalculatePricingPlanAmount.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Pricing\Actions;
+
+use Liberu\Billing\Pricing\Enums\PricingModel;
+use Liberu\Billing\Pricing\Models\PricingPlan;
+
+final class CalculatePricingPlanAmount
+{
+    /**
+     * Calculate a plan's charge in the plan currency's minor units.
+     *
+     * Tier ceilings are cumulative. The final tier is unbounded, matching the
+     * graduated pricing behavior of the legacy billing service.
+     *
+     * @param  array{quantity?: int|float}  $options
+     */
+    public function execute(PricingPlan $plan, array $options = []): int
+    {
+        $quantity = $options['quantity'] ?? 1;
+        if (! is_int($quantity) && ! is_float($quantity) || $quantity < 0) {
+            throw new \InvalidArgumentException('Pricing quantity must be zero or greater.');
+        }
+
+        if ($plan->pricing_model !== PricingModel::Usage && $plan->pricing_model !== PricingModel::Tiered) {
+            return (int) $plan->unit_amount_minor;
+        }
+
+        if ($plan->pricing_model === PricingModel::Usage && $plan->tiers === []) {
+            return (int) round($quantity * (int) $plan->unit_amount_minor);
+        }
+
+        $tiers = $plan->tiers;
+        if (! is_array($tiers) || $tiers === []) {
+            throw new \InvalidArgumentException('Tiered pricing requires tier definitions.');
+        }
+
+        $amount = 0;
+        $remaining = $quantity;
+        $previousCeiling = 0.0;
+        foreach ($tiers as $tier) {
+            if (! is_array($tier)) {
+                throw new \InvalidArgumentException('Pricing tiers must be arrays.');
+            }
+            $rate = (int) ($tier['unit_amount_minor'] ?? $tier['rate'] ?? -1);
+            $ceiling = $tier['up_to'] ?? $tier['max_usage'] ?? null;
+            if ($rate < 0 || ($ceiling !== null && (! is_int($ceiling) && ! is_float($ceiling) || $ceiling < $previousCeiling))) {
+                throw new \InvalidArgumentException('Pricing tier definitions are invalid.');
+            }
+            if ($ceiling !== null) {
+                $previousCeiling = (float) $ceiling;
+            }
+        }
+
+        $previousCeiling = 0.0;
+        $lastTier = array_key_last($tiers);
+
+        foreach ($tiers as $index => $tier) {
+            $rate = (int) ($tier['unit_amount_minor'] ?? $tier['rate'] ?? -1);
+            $ceiling = $tier['up_to'] ?? $tier['max_usage'] ?? null;
+            if ($rate < 0 || ($ceiling !== null && (! is_int($ceiling) && ! is_float($ceiling) || $ceiling < $previousCeiling))) {
+                throw new \InvalidArgumentException('Pricing tier definitions are invalid.');
+            }
+
+            $width = $index === $lastTier || $ceiling === null
+                ? $remaining
+                : max(0.0, (float) $ceiling - $previousCeiling);
+            $tierQuantity = min($remaining, $width);
+            $amount += (int) round($tierQuantity * $rate);
+            $remaining -= $tierQuantity;
+            if ($ceiling !== null) {
+                $previousCeiling = (float) $ceiling;
+            }
+            if ($remaining <= 0) {
+                break;
+            }
+        }
+
+        return $amount;
+    }
+}

--- a/modules/billing-pricing/src/Actions/CreatePricingContract.php
+++ b/modules/billing-pricing/src/Actions/CreatePricingContract.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Pricing\Actions;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+use Liberu\Billing\Pricing\Models\PricingContract;
+use Liberu\Billing\Pricing\Support\CustomerReference;
+
+final readonly class CreatePricingContract
+{
+    public function __construct(private DatabaseManager $database) {}
+
+    /** @param array<string, mixed> $attributes */
+    public function execute(array $attributes): PricingContract
+    {
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
+        $planId = $attributes['pricing_plan_id'] ?? null;
+
+        if ($planId === null || ! Schema::hasTable('billing_pricing_plans')) {
+            throw new \InvalidArgumentException('Pricing plan reference is invalid.');
+        }
+
+        $plan = $this->database->table('billing_pricing_plans')->where('id', (int) $planId)->first(['team_id']);
+        if ($plan === null || ($plan->team_id !== null && ($teamId === null || (int) $plan->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Pricing plan reference is invalid.');
+        }
+
+        return $this->database->transaction(fn (): PricingContract => PricingContract::query()->create([
+            'team_id' => $teamId,
+            'pricing_plan_id' => (int) $planId,
+            'customer_id' => $customerId,
+            'starts_at' => $attributes['starts_at'] ?? now(),
+            'ends_at' => $attributes['ends_at'] ?? null,
+            'terms' => $attributes['terms'] ?? [],
+            'status' => $attributes['status'] ?? 'active',
+        ]));
+    }
+}

--- a/modules/billing-pricing/src/Actions/CreatePricingPlan.php
+++ b/modules/billing-pricing/src/Actions/CreatePricingPlan.php
@@ -40,8 +40,9 @@ final readonly class CreatePricingPlan
 
         $productId = $attributes['product_id'] ?? null;
         if ($productId !== null && Schema::hasTable('billing_catalog_products')) {
-            $productTeam = $this->database->table('billing_catalog_products')->where('id', (int) $productId)->value('team_id');
-            if ($productTeam !== null && ($teamId = $attributes['team_id'] ?? null) !== null && (int) $productTeam !== (int) $teamId) {
+            $product = $this->database->table('billing_catalog_products')->where('id', (int) $productId)->first(['team_id']);
+            $teamId = $attributes['team_id'] ?? null;
+            if ($product === null || ($product->team_id !== null && ($teamId === null || (int) $product->team_id !== (int) $teamId))) {
                 throw new \InvalidArgumentException('Pricing product reference is invalid.');
             }
         } elseif ($productId !== null) {

--- a/modules/billing-pricing/src/Actions/CreatePricingPlan.php
+++ b/modules/billing-pricing/src/Actions/CreatePricingPlan.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\Billing\Pricing\Actions;
 
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Pricing\Enums\PricingModel;
 use Liberu\Billing\Pricing\Enums\PricingPlanStatus;
 use Liberu\Billing\Pricing\Models\PricingPlan;
@@ -37,9 +38,19 @@ final readonly class CreatePricingPlan
             throw new \InvalidArgumentException('Pricing amount and tiers are invalid.');
         }
 
+        $productId = $attributes['product_id'] ?? null;
+        if ($productId !== null && Schema::hasTable('billing_catalog_products')) {
+            $productTeam = $this->database->table('billing_catalog_products')->where('id', (int) $productId)->value('team_id');
+            if ($productTeam !== null && ($teamId = $attributes['team_id'] ?? null) !== null && (int) $productTeam !== (int) $teamId) {
+                throw new \InvalidArgumentException('Pricing product reference is invalid.');
+            }
+        } elseif ($productId !== null) {
+            throw new \InvalidArgumentException('Pricing product reference is invalid.');
+        }
+
         return $this->database->transaction(fn (): PricingPlan => PricingPlan::query()->create([
             'team_id' => $attributes['team_id'] ?? null,
-            'product_id' => $attributes['product_id'] ?? null,
+            'product_id' => $productId,
             'name' => $name,
             'pricing_model' => $model,
             'currency' => $currency,

--- a/modules/billing-pricing/src/Support/CustomerReference.php
+++ b/modules/billing-pricing/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Pricing\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null || $customerId === '') {
+            return null;
+        }
+
+        $normalizedCustomerId = (int) $customerId;
+        if ($normalizedCustomerId < 1 || ! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Pricing customer reference is invalid.');
+        }
+
+        $customer = $database->table('customers')->where('id', $normalizedCustomerId)->first(['team_id']);
+        if ($customer === null || ($customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Pricing customer reference is invalid.');
+        }
+
+        return $normalizedCustomerId;
+    }
+}

--- a/modules/module-billing-collections-api/src/Http/Controllers/CollectionCaseController.php
+++ b/modules/module-billing-collections-api/src/Http/Controllers/CollectionCaseController.php
@@ -43,6 +43,7 @@ final class CollectionCaseController extends Controller
 
     public function promise(Request $request, CollectionCase $case, PromisePayment $promise): JsonResponse
     {
+        $case = $this->forCurrentTeam($request, $case);
         Gate::authorize('update', $case);
         $data = $request->validate(['due_at' => ['required', 'date', 'after:now']]);
 
@@ -51,14 +52,16 @@ final class CollectionCaseController extends Controller
 
     public function suspend(Request $request, CollectionCase $case, SuspendCollectionCase $suspend): JsonResponse
     {
+        $case = $this->forCurrentTeam($request, $case);
         Gate::authorize('update', $case);
         $data = $request->validate(['reason' => ['required', 'string', 'max:1000']]);
 
         return response()->json(['data' => $this->resource($suspend->execute($case, $data['reason']))]);
     }
 
-    public function recover(CollectionCase $case, RecoverCollectionCase $recover): JsonResponse
+    public function recover(Request $request, CollectionCase $case, RecoverCollectionCase $recover): JsonResponse
     {
+        $case = $this->forCurrentTeam($request, $case);
         Gate::authorize('update', $case);
 
         return response()->json(['data' => $this->resource($recover->execute($case))]);
@@ -66,6 +69,7 @@ final class CollectionCaseController extends Controller
 
     public function retry(Request $request, CollectionCase $case, RetryCollectionCase $retry): JsonResponse
     {
+        $case = $this->forCurrentTeam($request, $case);
         Gate::authorize('update', $case);
         $data = $request->validate(['next_action_at' => ['required', 'date', 'after:now']]);
 
@@ -74,6 +78,7 @@ final class CollectionCaseController extends Controller
 
     public function writeOff(Request $request, CollectionCase $case, WriteOffCollectionCase $writeOff): JsonResponse
     {
+        $case = $this->forCurrentTeam($request, $case);
         Gate::authorize('update', $case);
         $data = $request->validate(['reason' => ['required', 'string', 'max:1000']]);
 
@@ -82,6 +87,7 @@ final class CollectionCaseController extends Controller
 
     public function dunning(Request $request, CollectionCase $case, ScheduleDunning $schedule): JsonResponse
     {
+        $case = $this->forCurrentTeam($request, $case);
         Gate::authorize('update', $case);
         $data = $request->validate(['next_action_at' => ['required', 'date', 'after:now']]);
 
@@ -90,6 +96,7 @@ final class CollectionCaseController extends Controller
 
     public function reminder(Request $request, CollectionCase $case, ScheduleReminder $schedule): JsonResponse
     {
+        $case = $this->forCurrentTeam($request, $case);
         Gate::authorize('update', $case);
         $data = $request->validate(['next_action_at' => ['required', 'date', 'after:now']]);
 
@@ -98,6 +105,7 @@ final class CollectionCaseController extends Controller
 
     public function creditControl(Request $request, CollectionCase $case, ApplyCreditControl $apply): JsonResponse
     {
+        $case = $this->forCurrentTeam($request, $case);
         Gate::authorize('update', $case);
         $data = $request->validate(['level' => ['required', 'string', 'max:50'], 'reason' => ['nullable', 'string', 'max:1000']]);
 
@@ -107,5 +115,12 @@ final class CollectionCaseController extends Controller
     private function resource(CollectionCase $case): array
     {
         return ['id' => (string) $case->getKey(), 'type' => 'billing-collection-cases', 'attributes' => ['type' => $case->type, 'status' => $case->status->value, 'amount_minor' => $case->amount_minor, 'currency' => $case->currency, 'next_action_at' => $case->next_action_at?->toIso8601String(), 'promise_due_at' => $case->promise_due_at?->toIso8601String(), 'reason' => $case->reason]];
+    }
+
+    private function forCurrentTeam(Request $request, CollectionCase $case): CollectionCase
+    {
+        $teamId = data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id');
+
+        return CollectionCase::query()->whereKey($case->getKey())->where('team_id', $teamId)->firstOrFail();
     }
 }

--- a/modules/module-billing-collections/src/Actions/ApplyCreditControl.php
+++ b/modules/module-billing-collections/src/Actions/ApplyCreditControl.php
@@ -23,11 +23,16 @@ final readonly class ApplyCreditControl
         }
 
         return $this->database->transaction(function () use ($case, $level, $reason): CollectionCase {
-            $metadata = $case->metadata ?? [];
-            $metadata['credit_control_level'] = $level;
-            $case->update(['type' => 'credit_control', 'reason' => $reason ?: $case->reason, 'metadata' => $metadata]);
+            $locked = CollectionCase::query()->lockForUpdate()->findOrFail($case->getKey());
+            if (in_array($locked->status, [CollectionStatus::Recovered, CollectionStatus::WrittenOff, CollectionStatus::Closed], true)) {
+                throw new \LogicException('Credit control cannot be applied to a terminal case.');
+            }
 
-            return $case->refresh();
+            $metadata = $locked->metadata ?? [];
+            $metadata['credit_control_level'] = $level;
+            $locked->update(['type' => 'credit_control', 'reason' => $reason ?: $locked->reason, 'metadata' => $metadata]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-collections/src/Actions/OpenCollectionCase.php
+++ b/modules/module-billing-collections/src/Actions/OpenCollectionCase.php
@@ -8,6 +8,7 @@ use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Collections\Enums\CollectionStatus;
 use Liberu\Billing\Collections\Models\CollectionCase;
+use Liberu\Billing\Collections\Support\CustomerReference;
 
 final readonly class OpenCollectionCase
 {
@@ -25,6 +26,9 @@ final readonly class OpenCollectionCase
             throw new \InvalidArgumentException('Collection case type is invalid.');
         }
 
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
+
         $invoiceId = $attributes['invoice_id'] ?? null;
         if ($invoiceId !== null && Schema::hasTable('billing_invoices')) {
             $invoiceTeam = $this->database->table('billing_invoices')->where('id', (int) $invoiceId)->value('team_id');
@@ -36,7 +40,7 @@ final readonly class OpenCollectionCase
         }
 
         return $this->database->transaction(fn (): CollectionCase => CollectionCase::query()->create([
-            'team_id' => $attributes['team_id'] ?? null, 'customer_id' => $attributes['customer_id'] ?? null, 'invoice_id' => $invoiceId,
+            'team_id' => $teamId, 'customer_id' => $customerId, 'invoice_id' => $invoiceId,
             'type' => $type, 'status' => CollectionStatus::Open, 'amount_minor' => $amount, 'currency' => $currency,
             'next_action_at' => $attributes['next_action_at'] ?? now(), 'reason' => $attributes['reason'] ?? null, 'metadata' => $attributes['metadata'] ?? [],
         ]));

--- a/modules/module-billing-collections/src/Actions/OpenCollectionCase.php
+++ b/modules/module-billing-collections/src/Actions/OpenCollectionCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\Billing\Collections\Actions;
 
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Collections\Enums\CollectionStatus;
 use Liberu\Billing\Collections\Models\CollectionCase;
 
@@ -24,8 +25,18 @@ final readonly class OpenCollectionCase
             throw new \InvalidArgumentException('Collection case type is invalid.');
         }
 
+        $invoiceId = $attributes['invoice_id'] ?? null;
+        if ($invoiceId !== null && Schema::hasTable('billing_invoices')) {
+            $invoiceTeam = $this->database->table('billing_invoices')->where('id', (int) $invoiceId)->value('team_id');
+            if ($invoiceTeam === null || (int) $invoiceTeam !== (int) ($attributes['team_id'] ?? 0)) {
+                throw new \InvalidArgumentException('Collection invoice reference is invalid.');
+            }
+        } elseif ($invoiceId !== null) {
+            throw new \InvalidArgumentException('Collection invoice reference is invalid.');
+        }
+
         return $this->database->transaction(fn (): CollectionCase => CollectionCase::query()->create([
-            'team_id' => $attributes['team_id'] ?? null, 'customer_id' => $attributes['customer_id'] ?? null, 'invoice_id' => $attributes['invoice_id'] ?? null,
+            'team_id' => $attributes['team_id'] ?? null, 'customer_id' => $attributes['customer_id'] ?? null, 'invoice_id' => $invoiceId,
             'type' => $type, 'status' => CollectionStatus::Open, 'amount_minor' => $amount, 'currency' => $currency,
             'next_action_at' => $attributes['next_action_at'] ?? now(), 'reason' => $attributes['reason'] ?? null, 'metadata' => $attributes['metadata'] ?? [],
         ]));

--- a/modules/module-billing-collections/src/Actions/OpenCollectionCase.php
+++ b/modules/module-billing-collections/src/Actions/OpenCollectionCase.php
@@ -16,13 +16,17 @@ final readonly class OpenCollectionCase
     {
         $amount = (int) ($attributes['amount_minor'] ?? 0);
         $currency = strtoupper((string) ($attributes['currency'] ?? ''));
+        $type = strtolower(trim((string) ($attributes['type'] ?? 'dunning')));
         if ($amount < 1 || ! preg_match('/^[A-Z]{3}$/', $currency)) {
             throw new \InvalidArgumentException('Collection amount and currency are invalid.');
+        }
+        if (! in_array($type, ['retry', 'dunning', 'reminder', 'promise', 'credit_control', 'suspension', 'write_off', 'recovery'], true)) {
+            throw new \InvalidArgumentException('Collection case type is invalid.');
         }
 
         return $this->database->transaction(fn (): CollectionCase => CollectionCase::query()->create([
             'team_id' => $attributes['team_id'] ?? null, 'customer_id' => $attributes['customer_id'] ?? null, 'invoice_id' => $attributes['invoice_id'] ?? null,
-            'type' => $attributes['type'] ?? 'dunning', 'status' => CollectionStatus::Open, 'amount_minor' => $amount, 'currency' => $currency,
+            'type' => $type, 'status' => CollectionStatus::Open, 'amount_minor' => $amount, 'currency' => $currency,
             'next_action_at' => $attributes['next_action_at'] ?? now(), 'reason' => $attributes['reason'] ?? null, 'metadata' => $attributes['metadata'] ?? [],
         ]));
     }

--- a/modules/module-billing-collections/src/Actions/PromisePayment.php
+++ b/modules/module-billing-collections/src/Actions/PromisePayment.php
@@ -19,9 +19,14 @@ final readonly class PromisePayment
         }
 
         return $this->database->transaction(function () use ($case, $dueAt): CollectionCase {
-            $case->update(['status' => CollectionStatus::Promised, 'promise_due_at' => $dueAt]);
+            $locked = CollectionCase::query()->lockForUpdate()->findOrFail($case->getKey());
+            if (in_array($locked->status, [CollectionStatus::WrittenOff, CollectionStatus::Recovered, CollectionStatus::Closed], true)) {
+                throw new \LogicException('This collection case cannot accept a promise.');
+            }
 
-            return $case->refresh();
+            $locked->update(['status' => CollectionStatus::Promised, 'promise_due_at' => $dueAt]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-collections/src/Actions/RecoverCollectionCase.php
+++ b/modules/module-billing-collections/src/Actions/RecoverCollectionCase.php
@@ -19,9 +19,14 @@ final readonly class RecoverCollectionCase
         }
 
         return $this->database->transaction(function () use ($case): CollectionCase {
-            $case->update(['status' => CollectionStatus::Recovered]);
+            $locked = CollectionCase::query()->lockForUpdate()->findOrFail($case->getKey());
+            if (in_array($locked->status, [CollectionStatus::Recovered, CollectionStatus::WrittenOff, CollectionStatus::Closed], true)) {
+                throw new \LogicException('This collection case cannot be recovered.');
+            }
 
-            return $case->refresh();
+            $locked->update(['status' => CollectionStatus::Recovered]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-collections/src/Actions/RetryCollectionCase.php
+++ b/modules/module-billing-collections/src/Actions/RetryCollectionCase.php
@@ -19,11 +19,16 @@ final readonly class RetryCollectionCase
         }
 
         return $this->database->transaction(function () use ($case, $nextActionAt): CollectionCase {
-            $metadata = $case->metadata ?? [];
-            $metadata['retry_count'] = ((int) ($metadata['retry_count'] ?? 0)) + 1;
-            $case->update(['status' => CollectionStatus::Open, 'next_action_at' => $nextActionAt, 'metadata' => $metadata]);
+            $locked = CollectionCase::query()->lockForUpdate()->findOrFail($case->getKey());
+            if (in_array($locked->status, [CollectionStatus::Recovered, CollectionStatus::WrittenOff, CollectionStatus::Closed], true)) {
+                throw new \LogicException('This collection case cannot be retried.');
+            }
 
-            return $case->refresh();
+            $metadata = $locked->metadata ?? [];
+            $metadata['retry_count'] = ((int) ($metadata['retry_count'] ?? 0)) + 1;
+            $locked->update(['status' => CollectionStatus::Open, 'next_action_at' => $nextActionAt, 'metadata' => $metadata]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-collections/src/Actions/ScheduleDunning.php
+++ b/modules/module-billing-collections/src/Actions/ScheduleDunning.php
@@ -19,11 +19,16 @@ final readonly class ScheduleDunning
         }
 
         return $this->database->transaction(function () use ($case, $nextActionAt): CollectionCase {
-            $metadata = $case->metadata ?? [];
-            $metadata['dunning_scheduled_at'] = now()->toIso8601String();
-            $case->update(['type' => 'dunning', 'status' => CollectionStatus::Open, 'next_action_at' => $nextActionAt, 'metadata' => $metadata]);
+            $locked = CollectionCase::query()->lockForUpdate()->findOrFail($case->getKey());
+            if (in_array($locked->status, [CollectionStatus::Recovered, CollectionStatus::WrittenOff, CollectionStatus::Closed], true)) {
+                throw new \LogicException('This collection case cannot be scheduled for dunning.');
+            }
 
-            return $case->refresh();
+            $metadata = $locked->metadata ?? [];
+            $metadata['dunning_scheduled_at'] = now()->toIso8601String();
+            $locked->update(['type' => 'dunning', 'status' => CollectionStatus::Open, 'next_action_at' => $nextActionAt, 'metadata' => $metadata]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-collections/src/Actions/ScheduleReminder.php
+++ b/modules/module-billing-collections/src/Actions/ScheduleReminder.php
@@ -19,11 +19,16 @@ final readonly class ScheduleReminder
         }
 
         return $this->database->transaction(function () use ($case, $nextActionAt): CollectionCase {
-            $metadata = $case->metadata ?? [];
-            $metadata['reminder_scheduled_at'] = now()->toIso8601String();
-            $case->update(['type' => 'reminder', 'next_action_at' => $nextActionAt, 'metadata' => $metadata]);
+            $locked = CollectionCase::query()->lockForUpdate()->findOrFail($case->getKey());
+            if (in_array($locked->status, [CollectionStatus::Recovered, CollectionStatus::WrittenOff, CollectionStatus::Closed], true)) {
+                throw new \LogicException('This collection case cannot receive a reminder.');
+            }
 
-            return $case->refresh();
+            $metadata = $locked->metadata ?? [];
+            $metadata['reminder_scheduled_at'] = now()->toIso8601String();
+            $locked->update(['type' => 'reminder', 'next_action_at' => $nextActionAt, 'metadata' => $metadata]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-collections/src/Actions/SuspendCollectionCase.php
+++ b/modules/module-billing-collections/src/Actions/SuspendCollectionCase.php
@@ -14,14 +14,20 @@ final readonly class SuspendCollectionCase
 
     public function execute(CollectionCase $case, string $reason): CollectionCase
     {
-        if ($case->status === CollectionStatus::Closed || $case->status === CollectionStatus::WrittenOff) {
+        $reason = trim($reason);
+        if ($reason === '' || $case->status === CollectionStatus::Closed || $case->status === CollectionStatus::WrittenOff) {
             throw new \LogicException('This collection case cannot be suspended.');
         }
 
         return $this->database->transaction(function () use ($case, $reason): CollectionCase {
-            $case->update(['status' => CollectionStatus::Suspended, 'reason' => $reason]);
+            $locked = CollectionCase::query()->lockForUpdate()->findOrFail($case->getKey());
+            if ($locked->status === CollectionStatus::Closed || $locked->status === CollectionStatus::WrittenOff) {
+                throw new \LogicException('This collection case cannot be suspended.');
+            }
 
-            return $case->refresh();
+            $locked->update(['status' => CollectionStatus::Suspended, 'reason' => $reason]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-collections/src/Actions/WriteOffCollectionCase.php
+++ b/modules/module-billing-collections/src/Actions/WriteOffCollectionCase.php
@@ -14,14 +14,20 @@ final readonly class WriteOffCollectionCase
 
     public function execute(CollectionCase $case, string $reason): CollectionCase
     {
-        if (in_array($case->status, [CollectionStatus::Recovered, CollectionStatus::WrittenOff, CollectionStatus::Closed], true)) {
+        $reason = trim($reason);
+        if ($reason === '' || in_array($case->status, [CollectionStatus::Recovered, CollectionStatus::WrittenOff, CollectionStatus::Closed], true)) {
             throw new \LogicException('This collection case cannot be written off.');
         }
 
         return $this->database->transaction(function () use ($case, $reason): CollectionCase {
-            $case->update(['status' => CollectionStatus::WrittenOff, 'reason' => $reason]);
+            $locked = CollectionCase::query()->lockForUpdate()->findOrFail($case->getKey());
+            if (in_array($locked->status, [CollectionStatus::Recovered, CollectionStatus::WrittenOff, CollectionStatus::Closed], true)) {
+                throw new \LogicException('This collection case cannot be written off.');
+            }
 
-            return $case->refresh();
+            $locked->update(['status' => CollectionStatus::WrittenOff, 'reason' => $reason]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-collections/src/Support/CustomerReference.php
+++ b/modules/module-billing-collections/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Collections\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $hasTeam = Schema::hasColumn('customers', 'team_id');
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($hasTeam ? ['team_id'] : ['id']);
+        if ($customer === null || ($hasTeam && $customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/modules/module-billing-communications/src/Actions/ProvisionCommunicationNumber.php
+++ b/modules/module-billing-communications/src/Actions/ProvisionCommunicationNumber.php
@@ -7,6 +7,7 @@ namespace Liberu\Billing\Communications\Actions;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Liberu\Billing\Communications\Models\CommunicationNumber;
+use Liberu\Billing\Communications\Models\CommunicationService;
 
 final class ProvisionCommunicationNumber
 {
@@ -18,6 +19,11 @@ final class ProvisionCommunicationNumber
             throw new InvalidArgumentException('A team and number are required.');
         }
 
-        return DB::transaction(fn (): CommunicationNumber => CommunicationNumber::query()->create(['team_id' => $teamId, 'service_id' => $attributes['service_id'] ?? null, 'number' => $number, 'type' => $attributes['type'] ?? 'phone', 'status' => 'active', 'metadata' => $attributes['metadata'] ?? []]));
+        $serviceId = $attributes['service_id'] ?? null;
+        if ($serviceId !== null) {
+            CommunicationService::query()->forTeam($teamId)->findOrFail((int) $serviceId);
+        }
+
+        return DB::transaction(fn (): CommunicationNumber => CommunicationNumber::query()->create(['team_id' => $teamId, 'service_id' => $serviceId, 'number' => $number, 'type' => $attributes['type'] ?? 'phone', 'status' => 'active', 'metadata' => $attributes['metadata'] ?? []]));
     }
 }

--- a/modules/module-billing-communications/src/Actions/TransitionCommunicationNumber.php
+++ b/modules/module-billing-communications/src/Actions/TransitionCommunicationNumber.php
@@ -17,9 +17,14 @@ final class TransitionCommunicationNumber
         }
 
         return DB::transaction(function () use ($number, $status): CommunicationNumber {
-            $number->update(['status' => $status]);
+            $locked = CommunicationNumber::query()->lockForUpdate()->findOrFail($number->getKey());
+            if ($locked->status === 'released' && $status !== 'released') {
+                throw new InvalidArgumentException('Released communication numbers cannot be reactivated.');
+            }
 
-            return $number->refresh();
+            $locked->update(['status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-communications/src/Actions/TransitionCommunicationService.php
+++ b/modules/module-billing-communications/src/Actions/TransitionCommunicationService.php
@@ -17,9 +17,14 @@ final class TransitionCommunicationService
         }
 
         return DB::transaction(function () use ($service, $status): CommunicationService {
-            $service->update(['status' => $status]);
+            $locked = CommunicationService::query()->lockForUpdate()->findOrFail($service->getKey());
+            if ($locked->status === 'cancelled' && $status !== 'cancelled') {
+                throw new InvalidArgumentException('Cancelled communication services cannot be reactivated.');
+            }
 
-            return $service->refresh();
+            $locked->update(['status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-customer-portal/src/Actions/CreatePortalItem.php
+++ b/modules/module-billing-customer-portal/src/Actions/CreatePortalItem.php
@@ -7,6 +7,7 @@ namespace Liberu\Billing\CustomerPortal\Actions;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Liberu\Billing\CustomerPortal\Models\PortalItem;
+use Liberu\Billing\CustomerPortal\Support\CustomerReference;
 
 final class CreatePortalItem
 {
@@ -19,6 +20,8 @@ final class CreatePortalItem
             throw new InvalidArgumentException('Portal item type and subject are invalid.');
         }
 
-        return DB::transaction(fn (): PortalItem => PortalItem::query()->create(['team_id' => $teamId, 'customer_id' => $attributes['customer_id'] ?? null, 'type' => $type, 'status' => 'open', 'subject' => $subject, 'payload' => $attributes['payload'] ?? []]));
+        $customerId = CustomerReference::assertBelongsToTeam(app('db'), $attributes['customer_id'] ?? null, $teamId);
+
+        return DB::transaction(fn (): PortalItem => PortalItem::query()->create(['team_id' => $teamId, 'customer_id' => $customerId, 'type' => $type, 'status' => 'open', 'subject' => $subject, 'payload' => $attributes['payload'] ?? []]));
     }
 }

--- a/modules/module-billing-customer-portal/src/Actions/TransitionPortalItem.php
+++ b/modules/module-billing-customer-portal/src/Actions/TransitionPortalItem.php
@@ -17,9 +17,14 @@ final class TransitionPortalItem
         }
 
         return DB::transaction(function () use ($item, $status): PortalItem {
-            $item->update(['status' => $status]);
+            $locked = PortalItem::query()->lockForUpdate()->findOrFail($item->getKey());
+            if (in_array($locked->status, ['completed', 'cancelled'], true) && $status !== $locked->status) {
+                throw new InvalidArgumentException('Completed or cancelled portal items cannot be reopened.');
+            }
 
-            return $item->refresh();
+            $locked->update(['status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-customer-portal/src/Actions/TransitionPortalRequest.php
+++ b/modules/module-billing-customer-portal/src/Actions/TransitionPortalRequest.php
@@ -17,9 +17,14 @@ final class TransitionPortalRequest
         }
 
         return DB::transaction(function () use ($request, $status): PortalRequest {
-            $request->update(['status' => $status]);
+            $locked = PortalRequest::query()->lockForUpdate()->findOrFail($request->getKey());
+            if ($locked->status === 'closed' && $status !== 'closed') {
+                throw new InvalidArgumentException('Closed portal requests cannot be reopened.');
+            }
 
-            return $request->refresh();
+            $locked->update(['status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-customer-portal/src/Support/CustomerReference.php
+++ b/modules/module-billing-customer-portal/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\CustomerPortal\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, int $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $hasTeam = Schema::hasColumn('customers', 'team_id');
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($hasTeam ? ['team_id'] : ['id']);
+        if ($customer === null || ($hasTeam && $customer->team_id !== null && (int) $customer->team_id !== $teamId)) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/modules/module-billing-domains-api/src/Http/Controllers/DomainController.php
+++ b/modules/module-billing-domains-api/src/Http/Controllers/DomainController.php
@@ -58,8 +58,9 @@ final class DomainController extends Controller
         return response()->json(['data' => $domains->items(), 'meta' => ['current_page' => $domains->currentPage(), 'last_page' => $domains->lastPage()]]);
     }
 
-    public function show(Domain $domain): Domain
+    public function show(Request $request, Domain $domain): Domain
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('view', $domain);
 
         return $domain;
@@ -75,13 +76,15 @@ final class DomainController extends Controller
 
     public function update(Request $request, Domain $domain, UpdateDomain $update): Domain
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('update', $domain);
 
         return $update->handle($domain, $request->validate($this->rules(false)));
     }
 
-    public function destroy(Domain $domain): JsonResponse
+    public function destroy(Request $request, Domain $domain): JsonResponse
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('delete', $domain);
         $domain->delete();
 
@@ -98,6 +101,7 @@ final class DomainController extends Controller
 
     public function register(Request $request, Domain $domain, RegisterDomain $register): Domain
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('update', $domain);
         $data = $request->validate(['customer_id' => ['required']]);
 
@@ -106,6 +110,7 @@ final class DomainController extends Controller
 
     public function renew(Request $request, Domain $domain, RenewDomain $renew): Domain
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('update', $domain);
 
         return $renew->execute($domain, $request->integer('period', 1));
@@ -113,6 +118,7 @@ final class DomainController extends Controller
 
     public function transfer(Request $request, Domain $domain, TransferDomain $transfer): Domain
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('update', $domain);
         $data = $request->validate(['auth_code' => ['required', 'string', 'max:255'], 'customer_id' => ['required'], 'registrar' => ['sometimes', 'nullable', 'string', 'max:50']]);
 
@@ -144,6 +150,7 @@ final class DomainController extends Controller
 
     public function dns(Request $request, Domain $domain): JsonResponse
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('view', $domain);
 
         return response()->json(DnsRecord::query()->where('team_id', $this->teamId($request))->where('domain_id', $domain->id)->latest()->get());
@@ -151,14 +158,16 @@ final class DomainController extends Controller
 
     public function storeDns(Request $request, Domain $domain, UpsertDnsRecord $upsert): JsonResponse
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('update', $domain);
         $data = $request->validate(['type' => ['required', 'string'], 'host' => ['required', 'string', 'max:255'], 'value' => ['required', 'string'], 'ttl' => ['sometimes', 'integer', 'min:60']]);
 
         return response()->json(['data' => $upsert->execute($this->teamId($request), [...$data, 'domain_id' => $domain->id])], 201);
     }
 
-    public function redeem(Domain $domain, RedeemDomain $redeem): Domain
+    public function redeem(Request $request, Domain $domain, RedeemDomain $redeem): Domain
     {
+        $domain = $this->forCurrentTeam($request, $domain);
         Gate::authorize('update', $domain);
 
         return $redeem->execute($domain);
@@ -181,5 +190,10 @@ final class DomainController extends Controller
     private function teamId(Request $request): int
     {
         return (int) (data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id'));
+    }
+
+    private function forCurrentTeam(Request $request, Domain $domain): Domain
+    {
+        return Domain::query()->forTeam($this->teamId($request))->whereKey($domain->getKey())->firstOrFail();
     }
 }

--- a/modules/module-billing-domains/src/Actions/RegisterDomain.php
+++ b/modules/module-billing-domains/src/Actions/RegisterDomain.php
@@ -7,6 +7,7 @@ namespace Liberu\Billing\Domains\Actions;
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Domains\Models\Domain;
 use Liberu\Billing\Domains\Services\RegistrarManager;
+use Liberu\Billing\Domains\Support\CustomerReference;
 
 final readonly class RegisterDomain
 {
@@ -14,6 +15,7 @@ final readonly class RegisterDomain
 
     public function execute(Domain $domain, mixed $customerId): Domain
     {
+        CustomerReference::assertBelongsToTeam($this->database, $customerId, $domain->team_id);
         $result = $this->registrars->client((string) $domain->registrar)->registerDomain($domain->name, $customerId);
         if ($result === null) {
             throw new \RuntimeException('The registrar rejected the domain registration.');

--- a/modules/module-billing-domains/src/Actions/TransferDomain.php
+++ b/modules/module-billing-domains/src/Actions/TransferDomain.php
@@ -7,6 +7,7 @@ namespace Liberu\Billing\Domains\Actions;
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Domains\Models\Domain;
 use Liberu\Billing\Domains\Services\RegistrarManager;
+use Liberu\Billing\Domains\Support\CustomerReference;
 
 final readonly class TransferDomain
 {
@@ -17,6 +18,7 @@ final readonly class TransferDomain
         if (trim($authCode) === '') {
             throw new \InvalidArgumentException('An EPP authorization code is required.');
         }
+        CustomerReference::assertBelongsToTeam($this->database, $customerId, $domain->team_id);
         $targetRegistrar = $registrar ?: (string) $domain->registrar;
         $result = $this->registrars->client($targetRegistrar)->transferDomain($domain->name, $authCode, $customerId);
         if ($result === null) {

--- a/modules/module-billing-domains/src/Actions/UpdateDomain.php
+++ b/modules/module-billing-domains/src/Actions/UpdateDomain.php
@@ -13,7 +13,8 @@ final class UpdateDomain
     public function handle(Domain $domain, array $attributes): Domain
     {
         return DB::transaction(function () use ($domain, $attributes): Domain {
-            $domain->fill(array_filter([
+            $locked = Domain::query()->lockForUpdate()->findOrFail($domain->getKey());
+            $locked->fill(array_filter([
                 'name' => array_key_exists('name', $attributes) ? $this->normalizeName((string) $attributes['name']) : null,
                 'status' => $attributes['status'] ?? null,
                 'registrar' => $attributes['registrar'] ?? null,
@@ -22,9 +23,9 @@ final class UpdateDomain
                 'registered_at' => $attributes['registered_at'] ?? null,
                 'metadata' => $attributes['metadata'] ?? null,
             ], static fn (mixed $value): bool => $value !== null));
-            $domain->save();
+            $locked->save();
 
-            return $domain->refresh();
+            return $locked->refresh();
         });
     }
 

--- a/modules/module-billing-domains/src/Actions/UpsertDnsRecord.php
+++ b/modules/module-billing-domains/src/Actions/UpsertDnsRecord.php
@@ -7,6 +7,7 @@ namespace Liberu\Billing\Domains\Actions;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Liberu\Billing\Domains\Models\DnsRecord;
+use Liberu\Billing\Domains\Models\Domain;
 
 final class UpsertDnsRecord
 {
@@ -14,10 +15,11 @@ final class UpsertDnsRecord
     public function execute(int $teamId, array $attributes): DnsRecord
     {
         $type = strtoupper((string) ($attributes['type'] ?? ''));
-        if ($teamId < 1 || ! in_array($type, ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS'], true) || trim((string) ($attributes['host'] ?? '')) === '' || trim((string) ($attributes['value'] ?? '')) === '') {
+        $domainId = (int) ($attributes['domain_id'] ?? 0);
+        if ($teamId < 1 || $domainId < 1 || ! in_array($type, ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS'], true) || trim((string) ($attributes['host'] ?? '')) === '' || trim((string) ($attributes['value'] ?? '')) === '' || ! Domain::query()->whereKey($domainId)->where('team_id', $teamId)->exists()) {
             throw new InvalidArgumentException('DNS record details are invalid.');
         }
 
-        return DB::transaction(fn (): DnsRecord => DnsRecord::query()->updateOrCreate(['team_id' => $teamId, 'domain_id' => (int) $attributes['domain_id'], 'type' => $type, 'host' => $attributes['host']], ['value' => $attributes['value'], 'ttl' => max(60, (int) ($attributes['ttl'] ?? 3600))]));
+        return DB::transaction(fn (): DnsRecord => DnsRecord::query()->updateOrCreate(['team_id' => $teamId, 'domain_id' => $domainId, 'type' => $type, 'host' => trim((string) $attributes['host'])], ['value' => trim((string) $attributes['value']), 'ttl' => max(60, (int) ($attributes['ttl'] ?? 3600))]));
     }
 }

--- a/modules/module-billing-domains/src/Services/RegistrarManager.php
+++ b/modules/module-billing-domains/src/Services/RegistrarManager.php
@@ -14,12 +14,17 @@ final class RegistrarManager
 
     public function register(string $name, RegistrarClient $client): void
     {
-        $this->clients[strtolower($name)] = $client;
+        $name = strtolower(trim($name));
+        if ($name === '') {
+            throw new InvalidArgumentException('Registrar name cannot be empty.');
+        }
+
+        $this->clients[$name] = $client;
     }
 
     public function client(string $name): RegistrarClient
     {
-        $client = $this->clients[strtolower($name)] ?? null;
+        $client = $this->clients[strtolower(trim($name))] ?? null;
         if (! $client instanceof RegistrarClient) {
             throw new InvalidArgumentException("Registrar [$name] is not registered.");
         }

--- a/modules/module-billing-domains/src/Support/CustomerReference.php
+++ b/modules/module-billing-domains/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Domains\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $hasTeam = Schema::hasColumn('customers', 'team_id');
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($hasTeam ? ['team_id'] : ['id']);
+        if ($customer === null || ($hasTeam && $customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/modules/module-billing-hosting-api/src/Http/Controllers/HostingCapabilityController.php
+++ b/modules/module-billing-hosting-api/src/Http/Controllers/HostingCapabilityController.php
@@ -42,6 +42,7 @@ final class HostingCapabilityController extends Controller
 
     public function transition(Request $request, HostingCapability $capability, TransitionHostingCapability $transition): JsonResponse
     {
+        $capability = HostingCapability::query()->where('team_id', $this->team($request))->findOrFail($capability->getKey());
         Gate::authorize('update', $capability);
         $data = $request->validate(['status' => ['required', 'string']]);
 

--- a/modules/module-billing-hosting/src/Actions/CreateHostingAccount.php
+++ b/modules/module-billing-hosting/src/Actions/CreateHostingAccount.php
@@ -14,12 +14,13 @@ final class CreateHostingAccount
     public function handle(int $teamId, array $attributes): HostingAccount
     {
         $name = trim((string) ($attributes['name'] ?? ''));
-        if ($teamId < 1 || $name === '') {
+        $status = (string) ($attributes['status'] ?? 'active');
+        if ($teamId < 1 || $name === '' || ! in_array($status, ['pending', 'active', 'suspended', 'cancelled', 'failed'], true)) {
             throw new InvalidArgumentException('A team and name are required.');
         }
 
         return DB::transaction(fn (): HostingAccount => HostingAccount::query()->create([
-            'team_id' => $teamId, 'name' => $name, 'status' => $attributes['status'] ?? 'active', 'metadata' => $attributes['metadata'] ?? null,
+            'team_id' => $teamId, 'name' => $name, 'status' => $status, 'metadata' => $attributes['metadata'] ?? null,
         ]));
     }
 }

--- a/modules/module-billing-hosting/src/Actions/CreateHostingCapability.php
+++ b/modules/module-billing-hosting/src/Actions/CreateHostingCapability.php
@@ -6,6 +6,7 @@ namespace Liberu\Billing\Hosting\Actions;
 
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
+use Liberu\Billing\Hosting\Models\HostingAccount;
 use Liberu\Billing\Hosting\Models\HostingCapability;
 
 final class CreateHostingCapability
@@ -19,6 +20,11 @@ final class CreateHostingCapability
             throw new InvalidArgumentException('Hosting capability type and name are invalid.');
         }
 
-        return DB::transaction(fn (): HostingCapability => HostingCapability::query()->create(['team_id' => $teamId, 'hosting_account_id' => $attributes['hosting_account_id'] ?? null, 'type' => $type, 'name' => $name, 'status' => 'pending', 'provider' => $attributes['provider'] ?? null, 'configuration' => $attributes['configuration'] ?? []]));
+        $accountId = $attributes['hosting_account_id'] ?? null;
+        if ($accountId !== null) {
+            HostingAccount::query()->forTeam($teamId)->findOrFail((int) $accountId);
+        }
+
+        return DB::transaction(fn (): HostingCapability => HostingCapability::query()->create(['team_id' => $teamId, 'hosting_account_id' => $accountId, 'type' => $type, 'name' => $name, 'status' => 'pending', 'provider' => $attributes['provider'] ?? null, 'configuration' => $attributes['configuration'] ?? []]));
     }
 }

--- a/modules/module-billing-hosting/src/Actions/TransitionHostingAccount.php
+++ b/modules/module-billing-hosting/src/Actions/TransitionHostingAccount.php
@@ -17,9 +17,15 @@ final class TransitionHostingAccount
         }
 
         return DB::transaction(function () use ($account, $status): HostingAccount {
-            $account->update(['status' => $status]);
+            $lockedAccount = HostingAccount::query()->lockForUpdate()->findOrFail($account->getKey());
 
-            return $account->refresh();
+            if ($lockedAccount->status === 'cancelled' && $status !== 'cancelled') {
+                throw new InvalidArgumentException('Cancelled hosting accounts cannot be reactivated.');
+            }
+
+            $lockedAccount->update(['status' => $status]);
+
+            return $lockedAccount->refresh();
         });
     }
 }

--- a/modules/module-billing-hosting/src/Actions/TransitionHostingCapability.php
+++ b/modules/module-billing-hosting/src/Actions/TransitionHostingCapability.php
@@ -17,9 +17,14 @@ final class TransitionHostingCapability
         }
 
         return DB::transaction(function () use ($capability, $status): HostingCapability {
-            $capability->update(['status' => $status]);
+            $locked = HostingCapability::query()->lockForUpdate()->findOrFail($capability->getKey());
+            if ($locked->status === 'cancelled' && $status !== 'cancelled') {
+                throw new InvalidArgumentException('Cancelled hosting capabilities cannot be reactivated.');
+            }
 
-            return $capability->refresh();
+            $locked->update(['status' => $status]);
+
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-hosting/src/Services/HostingDriverRegistry.php
+++ b/modules/module-billing-hosting/src/Services/HostingDriverRegistry.php
@@ -14,7 +14,7 @@ final class HostingDriverRegistry
 
     public function register(HostingDriver $driver): void
     {
-        $key = trim($driver->key());
+        $key = strtolower(trim($driver->key()));
         if ($key === '' || isset($this->drivers[$key])) {
             throw new InvalidArgumentException('Hosting driver keys must be non-empty and unique.');
         }
@@ -24,6 +24,8 @@ final class HostingDriverRegistry
 
     public function resolve(string $key): HostingDriver
     {
+        $key = strtolower(trim($key));
+
         return $this->drivers[$key] ?? throw new InvalidArgumentException("Hosting driver [{$key}] is not registered.");
     }
 

--- a/modules/module-billing-invoicing-api/src/Http/Controllers/InvoiceController.php
+++ b/modules/module-billing-invoicing-api/src/Http/Controllers/InvoiceController.php
@@ -43,6 +43,7 @@ final class InvoiceController extends Controller
 
     public function line(Request $request, Invoice $invoice, AddInvoiceLine $add): JsonResponse
     {
+        $invoice = $this->forCurrentTeam($request, $invoice);
         Gate::authorize('update', $invoice);
         $data = $request->validate(['description' => ['required', 'string', 'max:1000'], 'quantity' => ['required', 'integer', 'min:1'], 'unit_amount_minor' => ['required', 'integer', 'min:0'], 'tax_rate' => ['sometimes', 'numeric', 'min:0', 'max:100']]);
         $add->execute($invoice, $data['description'], $data['quantity'], $data['unit_amount_minor'], (float) ($data['tax_rate'] ?? 0));
@@ -50,8 +51,9 @@ final class InvoiceController extends Controller
         return response()->json(['data' => $this->resource($invoice->refresh())]);
     }
 
-    public function finalize(Invoice $invoice, FinalizeInvoice $finalize): JsonResponse
+    public function finalize(Request $request, Invoice $invoice, FinalizeInvoice $finalize): JsonResponse
     {
+        $invoice = $this->forCurrentTeam($request, $invoice);
         Gate::authorize('update', $invoice);
 
         return response()->json(['data' => $this->resource($finalize->execute($invoice))]);
@@ -73,8 +75,9 @@ final class InvoiceController extends Controller
         return response()->json(['data' => $this->scheduleResource($create->execute($data))], 201);
     }
 
-    public function runSchedule(InvoiceSchedule $schedule, RunInvoiceSchedule $run): JsonResponse
+    public function runSchedule(Request $request, InvoiceSchedule $schedule, RunInvoiceSchedule $run): JsonResponse
     {
+        $schedule = $this->forCurrentTeamSchedule($request, $schedule);
         Gate::authorize('update', $schedule);
 
         return response()->json(['data' => $this->resource($run->execute($schedule))]);
@@ -82,6 +85,7 @@ final class InvoiceController extends Controller
 
     public function adjust(Request $request, Invoice $invoice, ApplyInvoiceAdjustment $adjust): JsonResponse
     {
+        $invoice = $this->forCurrentTeam($request, $invoice);
         Gate::authorize('update', $invoice);
         $data = $request->validate(['amount_minor' => ['required', 'integer', 'not_in:0'], 'reason' => ['required', 'string', 'max:1000'], 'type' => ['sometimes', 'in:credit,adjustment']]);
         $amount = (int) $data['amount_minor'];
@@ -92,8 +96,9 @@ final class InvoiceController extends Controller
         return response()->json(['data' => $this->resource($adjust->execute($invoice, $amount, $data['reason'], $data['type'] ?? 'adjustment'))]);
     }
 
-    public function document(Invoice $invoice, GenerateInvoiceDocument $document): JsonResponse
+    public function document(Request $request, Invoice $invoice, GenerateInvoiceDocument $document): JsonResponse
     {
+        $invoice = $this->forCurrentTeam($request, $invoice);
         Gate::authorize('update', $invoice);
 
         return response()->json(['data' => $document->execute($invoice)]);
@@ -101,6 +106,7 @@ final class InvoiceController extends Controller
 
     public function deliver(Request $request, Invoice $invoice, DeliverInvoice $deliver): JsonResponse
     {
+        $invoice = $this->forCurrentTeam($request, $invoice);
         Gate::authorize('update', $invoice);
         $data = $request->validate(['destination' => ['required', 'email', 'max:255'], 'document_id' => ['nullable', 'integer', 'min:1']]);
 
@@ -115,5 +121,19 @@ final class InvoiceController extends Controller
     private function scheduleResource(InvoiceSchedule $schedule): array
     {
         return ['id' => (string) $schedule->getKey(), 'type' => 'billing-invoice-schedules', 'attributes' => ['frequency' => $schedule->frequency, 'next_run_at' => $schedule->next_run_at?->toIso8601String(), 'active' => $schedule->active, 'metadata' => $schedule->metadata]];
+    }
+
+    private function forCurrentTeam(Request $request, Invoice $invoice): Invoice
+    {
+        $teamId = data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id');
+
+        return Invoice::query()->whereKey($invoice->getKey())->where('team_id', $teamId)->firstOrFail();
+    }
+
+    private function forCurrentTeamSchedule(Request $request, InvoiceSchedule $schedule): InvoiceSchedule
+    {
+        $teamId = data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id');
+
+        return InvoiceSchedule::query()->whereKey($schedule->getKey())->where('team_id', $teamId)->firstOrFail();
     }
 }

--- a/modules/module-billing-invoicing-livewire/src/Components/InvoiceList.php
+++ b/modules/module-billing-invoicing-livewire/src/Components/InvoiceList.php
@@ -52,8 +52,7 @@ final class InvoiceList extends Component
     public function adjust(ApplyInvoiceAdjustment $adjust): void
     {
         $this->validate(['selectedInvoiceId' => ['required', 'integer', 'min:1'], 'adjustmentMinor' => ['required', 'integer', 'not_in:0'], 'adjustmentReason' => ['required', 'string', 'max:1000']]);
-        $invoice = Invoice::query()->findOrFail($this->selectedInvoiceId);
-        Gate::authorize('update', $invoice);
+        $invoice = $this->authorizedInvoice($this->selectedInvoiceId);
         $adjust->execute($invoice, $this->adjustmentMinor, $this->adjustmentReason);
         $this->reset(['selectedInvoiceId', 'adjustmentMinor', 'adjustmentReason']);
         session()->flash('module-billing-invoicing-message', __('Invoice adjustment applied.'));
@@ -78,7 +77,8 @@ final class InvoiceList extends Component
 
     private function authorizedInvoice(int $invoiceId): Invoice
     {
-        $invoice = Invoice::query()->findOrFail($invoiceId);
+        $teamId = data_get(auth()->user(), 'current_team_id') ?? data_get(auth()->user(), 'currentTeam.id');
+        $invoice = Invoice::query()->whereKey($invoiceId)->where('team_id', $teamId)->firstOrFail();
         Gate::authorize('update', $invoice);
 
         return $invoice;

--- a/modules/module-billing-invoicing/src/Actions/ApplyInvoiceLateFee.php
+++ b/modules/module-billing-invoicing/src/Actions/ApplyInvoiceLateFee.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Invoicing\Actions;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\DatabaseManager;
+use Liberu\Billing\Invoicing\Enums\InvoiceStatus;
+use Liberu\Billing\Invoicing\Models\Invoice;
+use Liberu\Billing\Invoicing\Models\InvoiceSupport;
+
+final readonly class ApplyInvoiceLateFee
+{
+    public function __construct(private DatabaseManager $database) {}
+
+    public function execute(Invoice $invoice, int $amountMinor, ?CarbonInterface $at = null): Invoice
+    {
+        if ($amountMinor < 1) {
+            throw new \InvalidArgumentException('Invoice late fee must be positive.');
+        }
+
+        $at ??= now();
+
+        return $this->database->transaction(function () use ($invoice, $amountMinor, $at): Invoice {
+            $locked = Invoice::query()->lockForUpdate()->findOrFail($invoice->getKey());
+            if ($locked->status !== InvoiceStatus::Finalized || $locked->due_at === null || $locked->due_at->isAfter($at)) {
+                throw new \LogicException('Only overdue finalized invoices can receive a late fee.');
+            }
+
+            $metadata = is_array($locked->metadata) ? $locked->metadata : [];
+            $feeDate = $at->toDateString();
+            $lateFees = is_array($metadata['late_fees'] ?? null) ? $metadata['late_fees'] : [];
+            foreach ($lateFees as $lateFee) {
+                if (is_array($lateFee) && ($lateFee['date'] ?? null) === $feeDate) {
+                    return $locked->refresh();
+                }
+            }
+
+            $lateFees[] = ['date' => $feeDate, 'amount_minor' => $amountMinor, 'applied_at' => $at->toIso8601String()];
+            $metadata['late_fees'] = $lateFees;
+            $locked->update(['total_minor' => (int) $locked->total_minor + $amountMinor, 'metadata' => $metadata]);
+            InvoiceSupport::query()->create([
+                'team_id' => $locked->team_id,
+                'invoice_id' => $locked->getKey(),
+                'type' => 'adjustment',
+                'status' => 'applied',
+                'amount_minor' => $amountMinor,
+                'currency' => $locked->currency,
+                'payload' => ['amount_minor' => $amountMinor, 'reason' => 'late_fee', 'date' => $feeDate],
+            ]);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/modules/module-billing-invoicing/src/Actions/CreateInvoice.php
+++ b/modules/module-billing-invoicing/src/Actions/CreateInvoice.php
@@ -7,6 +7,7 @@ namespace Liberu\Billing\Invoicing\Actions;
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Invoicing\Enums\InvoiceStatus;
 use Liberu\Billing\Invoicing\Models\Invoice;
+use Liberu\Billing\Invoicing\Support\CustomerReference;
 
 final readonly class CreateInvoice
 {
@@ -19,8 +20,11 @@ final readonly class CreateInvoice
             throw new \InvalidArgumentException('Invoice currency is invalid.');
         }
 
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
+
         return $this->database->transaction(fn (): Invoice => Invoice::query()->create([
-            'team_id' => $attributes['team_id'] ?? null, 'customer_id' => $attributes['customer_id'] ?? null,
+            'team_id' => $teamId, 'customer_id' => $customerId,
             'number' => $attributes['number'] ?? null, 'status' => InvoiceStatus::Draft, 'currency' => $currency,
             'subtotal_minor' => 0, 'tax_minor' => 0, 'total_minor' => 0, 'due_at' => $attributes['due_at'] ?? null, 'metadata' => $attributes['metadata'] ?? [],
         ]));

--- a/modules/module-billing-invoicing/src/Actions/CreateInvoiceSchedule.php
+++ b/modules/module-billing-invoicing/src/Actions/CreateInvoiceSchedule.php
@@ -6,6 +6,7 @@ namespace Liberu\Billing\Invoicing\Actions;
 
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Invoicing\Models\InvoiceSchedule;
+use Liberu\Billing\Invoicing\Support\CustomerReference;
 
 final readonly class CreateInvoiceSchedule
 {
@@ -23,9 +24,12 @@ final readonly class CreateInvoiceSchedule
             throw new \InvalidArgumentException('Invoice schedule metadata must be an array.');
         }
 
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
+
         return $this->database->transaction(fn (): InvoiceSchedule => InvoiceSchedule::query()->create([
-            'team_id' => $attributes['team_id'] ?? null,
-            'customer_id' => $attributes['customer_id'] ?? null,
+            'team_id' => $teamId,
+            'customer_id' => $customerId,
             'frequency' => $frequency,
             'next_run_at' => $attributes['next_run_at'] ?? now(),
             'active' => $attributes['active'] ?? true,

--- a/modules/module-billing-invoicing/src/Actions/DeliverInvoice.php
+++ b/modules/module-billing-invoicing/src/Actions/DeliverInvoice.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\Billing\Invoicing\Actions;
 
 use Illuminate\Database\DatabaseManager;
+use Liberu\Billing\Invoicing\Enums\InvoiceStatus;
 use Liberu\Billing\Invoicing\Models\Invoice;
 use Liberu\Billing\Invoicing\Models\InvoiceSupport;
 
@@ -18,6 +19,13 @@ final readonly class DeliverInvoice
             throw new \InvalidArgumentException('A valid invoice delivery destination is required.');
         }
 
-        return $this->database->transaction(fn (): InvoiceSupport => InvoiceSupport::query()->create(['team_id' => $invoice->team_id, 'invoice_id' => $invoice->getKey(), 'type' => 'delivery', 'status' => 'delivered', 'amount_minor' => 0, 'currency' => $invoice->currency, 'destination' => strtolower(trim($destination)), 'payload' => ['document_id' => $documentId]]));
+        return $this->database->transaction(function () use ($invoice, $destination, $documentId): InvoiceSupport {
+            $locked = Invoice::query()->lockForUpdate()->findOrFail($invoice->getKey());
+            if (! in_array($locked->status, [InvoiceStatus::Finalized, InvoiceStatus::Paid], true)) {
+                throw new \LogicException('Only finalized invoices can be delivered.');
+            }
+
+            return InvoiceSupport::query()->create(['team_id' => $locked->team_id, 'invoice_id' => $locked->getKey(), 'type' => 'delivery', 'status' => 'delivered', 'amount_minor' => 0, 'currency' => $locked->currency, 'destination' => strtolower(trim($destination)), 'payload' => ['document_id' => $documentId]]);
+        });
     }
 }

--- a/modules/module-billing-invoicing/src/Actions/RunInvoiceSchedule.php
+++ b/modules/module-billing-invoicing/src/Actions/RunInvoiceSchedule.php
@@ -21,43 +21,46 @@ final readonly class RunInvoiceSchedule
 
     public function execute(InvoiceSchedule $schedule, ?CarbonInterface $at = null): Invoice
     {
-        if (! $schedule->active) {
-            throw new \LogicException('Inactive invoice schedules cannot be run.');
-        }
-
         $at ??= now();
-        if ($schedule->next_run_at !== null && $schedule->next_run_at->isFuture()) {
-            throw new \LogicException('Invoice schedule is not due yet.');
-        }
 
-        $metadata = is_array($schedule->metadata) ? $schedule->metadata : [];
-        $invoice = $this->createInvoice->execute([
-            'team_id' => $schedule->team_id,
-            'customer_id' => $schedule->customer_id,
-            'currency' => $metadata['currency'] ?? 'USD',
-            'due_at' => $metadata['due_at'] ?? null,
-            'metadata' => ['invoice_schedule_id' => $schedule->getKey()],
-        ]);
-
-        foreach (($metadata['lines'] ?? []) as $line) {
-            if (! is_array($line)) {
-                throw new \InvalidArgumentException('Invoice schedule lines must be arrays.');
-            }
-            $this->addInvoiceLine->execute(
-                $invoice->refresh(),
-                (string) ($line['description'] ?? ''),
-                (int) ($line['quantity'] ?? 0),
-                (int) ($line['unit_amount_minor'] ?? -1),
-                (float) ($line['tax_rate'] ?? 0),
-            );
-        }
-
-        if ($invoice->refresh()->status === InvoiceStatus::Draft && $invoice->lines()->exists()) {
-            $invoice = $this->finalizeInvoice->execute($invoice->refresh());
-        }
-
-        $this->database->transaction(function () use ($schedule, $at): void {
+        return $this->database->transaction(function () use ($schedule, $at): Invoice {
+            // Claim the due schedule before creating the invoice. Keeping this
+            // lock for the whole transaction prevents concurrent workers from
+            // generating multiple invoices for the same billing period.
             $schedule = InvoiceSchedule::query()->lockForUpdate()->findOrFail($schedule->getKey());
+            if (! $schedule->active) {
+                throw new \LogicException('Inactive invoice schedules cannot be run.');
+            }
+            if ($schedule->next_run_at !== null && $schedule->next_run_at->isFuture()) {
+                throw new \LogicException('Invoice schedule is not due yet.');
+            }
+
+            $metadata = is_array($schedule->metadata) ? $schedule->metadata : [];
+            $invoice = $this->createInvoice->execute([
+                'team_id' => $schedule->team_id,
+                'customer_id' => $schedule->customer_id,
+                'currency' => $metadata['currency'] ?? 'USD',
+                'due_at' => $metadata['due_at'] ?? null,
+                'metadata' => ['invoice_schedule_id' => $schedule->getKey()],
+            ]);
+
+            foreach (($metadata['lines'] ?? []) as $line) {
+                if (! is_array($line)) {
+                    throw new \InvalidArgumentException('Invoice schedule lines must be arrays.');
+                }
+                $this->addInvoiceLine->execute(
+                    $invoice->refresh(),
+                    (string) ($line['description'] ?? ''),
+                    (int) ($line['quantity'] ?? 0),
+                    (int) ($line['unit_amount_minor'] ?? -1),
+                    (float) ($line['tax_rate'] ?? 0),
+                );
+            }
+
+            if ($invoice->refresh()->status === InvoiceStatus::Draft && $invoice->lines()->exists()) {
+                $invoice = $this->finalizeInvoice->execute($invoice->refresh());
+            }
+
             $nextRun = $schedule->next_run_at?->copy() ?? $at->copy();
             $nextRun = match ($schedule->frequency) {
                 'daily' => $nextRun->addDay(),
@@ -67,8 +70,8 @@ final readonly class RunInvoiceSchedule
                 default => throw new \LogicException('Invoice schedule frequency is invalid.'),
             };
             $schedule->update(['next_run_at' => $nextRun]);
-        });
 
-        return $invoice->refresh();
+            return $invoice->refresh();
+        });
     }
 }

--- a/modules/module-billing-invoicing/src/Models/Invoice.php
+++ b/modules/module-billing-invoicing/src/Models/Invoice.php
@@ -22,4 +22,9 @@ class Invoice extends Model
     {
         return $this->hasMany(InvoiceLine::class);
     }
+
+    public function supports()
+    {
+        return $this->hasMany(InvoiceSupport::class);
+    }
 }

--- a/modules/module-billing-invoicing/src/Support/CustomerReference.php
+++ b/modules/module-billing-invoicing/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Invoicing\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $hasTeam = Schema::hasColumn('customers', 'team_id');
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($hasTeam ? ['team_id'] : ['id']);
+        if ($customer === null || ($hasTeam && $customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/modules/module-billing-isp/src/Actions/TransitionAccessService.php
+++ b/modules/module-billing-isp/src/Actions/TransitionAccessService.php
@@ -15,11 +15,18 @@ final class TransitionAccessService
         if (! in_array($status, ['pending', 'active', 'suspended', 'cancelled', 'failed'], true)) {
             throw new InvalidArgumentException('ISP access-service lifecycle status is invalid.');
         }
+        if ($service->status === 'cancelled' && $status !== 'cancelled') {
+            throw new \LogicException('A cancelled ISP access service cannot be reactivated.');
+        }
 
         return DB::transaction(function () use ($service, $status): AccessService {
-            $service->update(['status' => $status]);
+            $locked = AccessService::query()->lockForUpdate()->findOrFail($service->getKey());
+            if ($locked->status === 'cancelled' && $status !== 'cancelled') {
+                throw new \LogicException('A cancelled ISP access service cannot be reactivated.');
+            }
+            $locked->update(['status' => $status]);
 
-            return $service->refresh();
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-isp/src/Actions/TransitionIspCapability.php
+++ b/modules/module-billing-isp/src/Actions/TransitionIspCapability.php
@@ -15,11 +15,18 @@ final class TransitionIspCapability
         if (! in_array($status, ['pending', 'active', 'suspended', 'cancelled', 'failed'], true)) {
             throw new InvalidArgumentException('ISP capability status is invalid.');
         }
+        if ($capability->status === 'cancelled' && $status !== 'cancelled') {
+            throw new \LogicException('A cancelled ISP capability cannot be reactivated.');
+        }
 
         return DB::transaction(function () use ($capability, $status): IspCapability {
-            $capability->update(['status' => $status]);
+            $locked = IspCapability::query()->lockForUpdate()->findOrFail($capability->getKey());
+            if ($locked->status === 'cancelled' && $status !== 'cancelled') {
+                throw new \LogicException('A cancelled ISP capability cannot be reactivated.');
+            }
+            $locked->update(['status' => $status]);
 
-            return $capability->refresh();
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-paddle/src/PaddleGatewayDriver.php
+++ b/modules/module-billing-paddle/src/PaddleGatewayDriver.php
@@ -26,11 +26,14 @@ final readonly class PaddleGatewayDriver implements GatewayDriver
         }
         $transaction = $this->request('post', 'transactions', $payload);
         $status = data_get($transaction, 'data.status');
-        if (! in_array($status, ['completed', 'billed', 'ready'], true)) {
+        $reference = data_get($transaction, 'data.id');
+        // `ready` only means that Paddle has prepared the transaction for
+        // checkout; it is not evidence that funds were collected.
+        if (! in_array($status, ['completed', 'billed', 'paid'], true) || ! is_string($reference) || $reference === '') {
             throw new \RuntimeException('Paddle transaction is not complete: '.(string) $status);
         }
 
-        return ['reference' => (string) data_get($transaction, 'data.id')];
+        return ['reference' => $reference];
     }
 
     public function refund(Payment $payment, int $amountMinor): array
@@ -50,7 +53,13 @@ final readonly class PaddleGatewayDriver implements GatewayDriver
             $payload['items'] = [['item_id' => $itemId, 'type' => 'partial', 'amount' => (string) $amountMinor]];
         }
 
-        return ['reference' => (string) data_get($this->request('post', 'adjustments', $payload), 'data.id')];
+        $response = $this->request('post', 'adjustments', $payload);
+        $providerReference = data_get($response, 'data.id');
+        if (! is_string($providerReference) || $providerReference === '') {
+            throw new \RuntimeException('Paddle refund did not return an adjustment reference.');
+        }
+
+        return ['reference' => $providerReference];
     }
 
     /** @return array<string,mixed> */

--- a/modules/module-billing-payments-api/src/Http/Controllers/PaymentController.php
+++ b/modules/module-billing-payments-api/src/Http/Controllers/PaymentController.php
@@ -45,8 +45,9 @@ final class PaymentController extends Controller
         return response()->json(['data' => $this->resource($create->execute($data))], 201);
     }
 
-    public function capture(Payment $payment, CapturePayment $capture): JsonResponse
+    public function capture(Request $request, Payment $payment, CapturePayment $capture): JsonResponse
     {
+        $payment = $this->forCurrentTeam($request, $payment);
         Gate::authorize('update', $payment);
 
         return response()->json(['data' => $this->resource($capture->execute($payment))]);
@@ -54,6 +55,7 @@ final class PaymentController extends Controller
 
     public function refund(Request $request, Payment $payment, RefundPayment $refund): JsonResponse
     {
+        $payment = $this->forCurrentTeam($request, $payment);
         Gate::authorize('update', $payment);
         $data = $request->validate(['amount_minor' => ['required', 'integer', 'min:1'], 'reason' => ['sometimes', 'string', 'max:255']]);
         $refund->execute($payment, (int) $data['amount_minor'], (string) ($data['reason'] ?? 'requested'));
@@ -63,6 +65,7 @@ final class PaymentController extends Controller
 
     public function dispute(Request $request, Payment $payment, OpenDispute $dispute): JsonResponse
     {
+        $payment = $this->forCurrentTeam($request, $payment);
         Gate::authorize('update', $payment);
         $data = $request->validate(['amount_minor' => ['required', 'integer', 'min:1'], 'reason' => ['required', 'string', 'max:255']]);
         $dispute->execute($payment, (int) $data['amount_minor'], $data['reason']);
@@ -72,6 +75,7 @@ final class PaymentController extends Controller
 
     public function allocate(Request $request, Payment $payment, AllocatePayment $allocate): JsonResponse
     {
+        $payment = $this->forCurrentTeam($request, $payment);
         Gate::authorize('update', $payment);
         $data = $request->validate(['amount_minor' => ['required', 'integer', 'min:1'], 'invoice_id' => ['nullable', 'integer', 'min:1']]);
         $allocation = $allocate->execute($payment, (int) $data['amount_minor'], isset($data['invoice_id']) ? (int) $data['invoice_id'] : null);
@@ -81,6 +85,7 @@ final class PaymentController extends Controller
 
     public function reconcile(Request $request, Payment $payment, ReconcilePayment $reconcile): JsonResponse
     {
+        $payment = $this->forCurrentTeam($request, $payment);
         Gate::authorize('update', $payment);
         $data = $request->validate(['provider_reference' => ['required', 'string', 'max:255'], 'matched' => ['sometimes', 'boolean'], 'notes' => ['nullable', 'string', 'max:2000']]);
         $record = $reconcile->execute($payment, $data['provider_reference'], (bool) ($data['matched'] ?? true), $data['notes'] ?? null);
@@ -100,5 +105,12 @@ final class PaymentController extends Controller
             'captured_at' => $payment->captured_at?->toIso8601String(),
             'refunded_minor' => $payment->refunded_minor,
         ]];
+    }
+
+    private function forCurrentTeam(Request $request, Payment $payment): Payment
+    {
+        $teamId = data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id');
+
+        return Payment::query()->whereKey($payment->getKey())->where('team_id', $teamId)->firstOrFail();
     }
 }

--- a/modules/module-billing-payments/src/Actions/AllocatePayment.php
+++ b/modules/module-billing-payments/src/Actions/AllocatePayment.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\Billing\Payments\Actions;
 
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Payments\Enums\PaymentStatus;
 use Liberu\Billing\Payments\Models\Payment;
 use Liberu\Billing\Payments\Models\PaymentAllocation;
@@ -20,6 +21,15 @@ final readonly class AllocatePayment
             $allocated = (int) $locked->allocations()->sum('amount_minor');
             if ($locked->status !== PaymentStatus::Captured || $amountMinor < 1 || $allocated + $amountMinor > (int) $locked->amount_minor) {
                 throw new \InvalidArgumentException('Allocation amount or payment state is invalid.');
+            }
+
+            if ($invoiceId !== null && Schema::hasTable('billing_invoices')) {
+                $invoice = $this->database->table('billing_invoices')->where('id', $invoiceId)->first(['team_id']);
+                if ($invoice === null || ($invoice->team_id !== null && ($locked->team_id === null || (int) $invoice->team_id !== (int) $locked->team_id))) {
+                    throw new \InvalidArgumentException('Payment invoice reference is invalid.');
+                }
+            } elseif ($invoiceId !== null) {
+                throw new \InvalidArgumentException('Payment invoice reference is invalid.');
             }
 
             return PaymentAllocation::query()->create([

--- a/modules/module-billing-payments/src/Actions/AllocatePayment.php
+++ b/modules/module-billing-payments/src/Actions/AllocatePayment.php
@@ -24,8 +24,8 @@ final readonly class AllocatePayment
             }
 
             if ($invoiceId !== null && Schema::hasTable('billing_invoices')) {
-                $invoice = $this->database->table('billing_invoices')->where('id', $invoiceId)->first(['team_id']);
-                if ($invoice === null || ($invoice->team_id !== null && ($locked->team_id === null || (int) $invoice->team_id !== (int) $locked->team_id))) {
+                $invoice = $this->database->table('billing_invoices')->where('id', $invoiceId)->first(['team_id', 'customer_id']);
+                if ($invoice === null || ($invoice->team_id !== null && ($locked->team_id === null || (int) $invoice->team_id !== (int) $locked->team_id)) || ($invoice->customer_id !== null && ($locked->customer_id === null || (int) $invoice->customer_id !== (int) $locked->customer_id))) {
                     throw new \InvalidArgumentException('Payment invoice reference is invalid.');
                 }
             } elseif ($invoiceId !== null) {

--- a/modules/module-billing-payments/src/Actions/CreatePayment.php
+++ b/modules/module-billing-payments/src/Actions/CreatePayment.php
@@ -7,6 +7,7 @@ namespace Liberu\Billing\Payments\Actions;
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Payments\Enums\PaymentStatus;
 use Liberu\Billing\Payments\Models\Payment;
+use Liberu\Billing\Payments\Support\CustomerReference;
 
 final readonly class CreatePayment
 {
@@ -21,9 +22,12 @@ final readonly class CreatePayment
             throw new \InvalidArgumentException('Payment amount and currency are invalid.');
         }
 
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
+
         return $this->database->transaction(fn (): Payment => Payment::query()->create([
-            'team_id' => $attributes['team_id'] ?? null,
-            'customer_id' => $attributes['customer_id'] ?? null,
+            'team_id' => $teamId,
+            'customer_id' => $customerId,
             'amount_minor' => $amount,
             'currency' => $currency,
             'status' => PaymentStatus::Pending,

--- a/modules/module-billing-payments/src/Actions/CreatePaymentMandate.php
+++ b/modules/module-billing-payments/src/Actions/CreatePaymentMandate.php
@@ -7,6 +7,7 @@ namespace Liberu\Billing\Payments\Actions;
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Payments\Models\PaymentMandate;
 use Liberu\Billing\Payments\Models\PaymentMethod;
+use Liberu\Billing\Payments\Support\CustomerReference;
 
 final readonly class CreatePaymentMandate
 {
@@ -20,13 +21,17 @@ final readonly class CreatePaymentMandate
         }
 
         $teamId = $attributes['team_id'] ?? null;
-        PaymentMethod::query()->whereKey((int) $attributes['payment_method_id'])
+        $method = PaymentMethod::query()->whereKey((int) $attributes['payment_method_id'])
             ->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $teamId))
             ->firstOrFail();
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
+        if ($customerId !== null && $method->customer_id !== null && (int) $method->customer_id !== $customerId) {
+            throw new \InvalidArgumentException('Payment method customer reference is invalid.');
+        }
 
         return $this->database->transaction(fn (): PaymentMandate => PaymentMandate::query()->create([
             'team_id' => $teamId,
-            'customer_id' => $attributes['customer_id'] ?? null,
+            'customer_id' => $customerId,
             'payment_method_id' => $attributes['payment_method_id'],
             'provider' => strtolower((string) $attributes['provider']),
             'provider_reference' => $attributes['provider_reference'] ?? null,

--- a/modules/module-billing-payments/src/Actions/CreatePaymentMandate.php
+++ b/modules/module-billing-payments/src/Actions/CreatePaymentMandate.php
@@ -6,6 +6,7 @@ namespace Liberu\Billing\Payments\Actions;
 
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Payments\Models\PaymentMandate;
+use Liberu\Billing\Payments\Models\PaymentMethod;
 
 final readonly class CreatePaymentMandate
 {
@@ -18,8 +19,13 @@ final readonly class CreatePaymentMandate
             throw new \InvalidArgumentException('Payment method and provider are required.');
         }
 
+        $teamId = $attributes['team_id'] ?? null;
+        PaymentMethod::query()->whereKey((int) $attributes['payment_method_id'])
+            ->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $teamId))
+            ->firstOrFail();
+
         return $this->database->transaction(fn (): PaymentMandate => PaymentMandate::query()->create([
-            'team_id' => $attributes['team_id'] ?? null,
+            'team_id' => $teamId,
             'customer_id' => $attributes['customer_id'] ?? null,
             'payment_method_id' => $attributes['payment_method_id'],
             'provider' => strtolower((string) $attributes['provider']),

--- a/modules/module-billing-payments/src/Actions/CreatePaymentMethod.php
+++ b/modules/module-billing-payments/src/Actions/CreatePaymentMethod.php
@@ -6,6 +6,7 @@ namespace Liberu\Billing\Payments\Actions;
 
 use Illuminate\Database\DatabaseManager;
 use Liberu\Billing\Payments\Models\PaymentMethod;
+use Liberu\Billing\Payments\Support\CustomerReference;
 
 final readonly class CreatePaymentMethod
 {
@@ -18,9 +19,12 @@ final readonly class CreatePaymentMethod
             throw new \InvalidArgumentException('Payment method type and provider are required.');
         }
 
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
+
         return $this->database->transaction(fn (): PaymentMethod => PaymentMethod::query()->create([
-            'team_id' => $attributes['team_id'] ?? null,
-            'customer_id' => $attributes['customer_id'] ?? null,
+            'team_id' => $teamId,
+            'customer_id' => $customerId,
             'type' => $attributes['type'],
             'provider' => strtolower((string) $attributes['provider']),
             'provider_reference' => $attributes['provider_reference'] ?? null,

--- a/modules/module-billing-payments/src/Actions/OpenDispute.php
+++ b/modules/module-billing-payments/src/Actions/OpenDispute.php
@@ -21,9 +21,14 @@ final readonly class OpenDispute
         }
 
         return $this->database->transaction(function () use ($payment, $amountMinor, $reason): PaymentDispute {
-            $payment->update(['status' => PaymentStatus::Disputed]);
+            $locked = Payment::query()->lockForUpdate()->findOrFail($payment->getKey());
+            if ($locked->status !== PaymentStatus::Captured || $amountMinor > (int) $locked->amount_minor) {
+                throw new \InvalidArgumentException('Dispute amount or payment state is invalid.');
+            }
 
-            return PaymentDispute::query()->create(['payment_id' => $payment->getKey(), 'amount_minor' => $amountMinor, 'status' => DisputeStatus::Open, 'reason' => trim($reason)]);
+            $locked->update(['status' => PaymentStatus::Disputed]);
+
+            return PaymentDispute::query()->create(['payment_id' => $locked->getKey(), 'amount_minor' => $amountMinor, 'status' => DisputeStatus::Open, 'reason' => trim($reason)]);
         });
     }
 }

--- a/modules/module-billing-payments/src/Actions/ReconcilePayment.php
+++ b/modules/module-billing-payments/src/Actions/ReconcilePayment.php
@@ -19,9 +19,23 @@ final readonly class ReconcilePayment
             throw new \InvalidArgumentException('A provider reference is required.');
         }
 
-        return $this->database->transaction(fn (): PaymentReconciliation => PaymentReconciliation::query()->create([
-            'payment_id' => $payment->getKey(), 'status' => $matched ? ReconciliationStatus::Matched : ReconciliationStatus::Mismatch,
-            'provider_reference' => trim($providerReference), 'notes' => $notes,
-        ]));
+        $providerReference = trim($providerReference);
+
+        return $this->database->transaction(function () use ($payment, $providerReference, $matched, $notes): PaymentReconciliation {
+            $locked = Payment::query()->lockForUpdate()->findOrFail($payment->getKey());
+            $existing = PaymentReconciliation::query()
+                ->where('payment_id', $locked->getKey())
+                ->where('provider_reference', $providerReference)
+                ->first();
+
+            if ($existing !== null) {
+                return $existing;
+            }
+
+            return PaymentReconciliation::query()->create([
+                'payment_id' => $locked->getKey(), 'status' => $matched ? ReconciliationStatus::Matched : ReconciliationStatus::Mismatch,
+                'provider_reference' => $providerReference, 'notes' => $notes,
+            ]);
+        });
     }
 }

--- a/modules/module-billing-payments/src/Services/GatewayManager.php
+++ b/modules/module-billing-payments/src/Services/GatewayManager.php
@@ -13,12 +13,17 @@ final class GatewayManager
 
     public function register(string $name, GatewayDriver $driver): void
     {
+        $name = strtolower(trim($name));
+        if ($name === '') {
+            throw new \InvalidArgumentException('Payment gateway name cannot be empty.');
+        }
+
         $this->drivers[$name] = $driver;
     }
 
     public function driver(string $name): GatewayDriver
     {
-        $driver = $this->drivers[$name] ?? null;
+        $driver = $this->drivers[strtolower(trim($name))] ?? null;
         if (! $driver instanceof GatewayDriver) {
             throw new \InvalidArgumentException("Payment gateway [$name] is not registered.");
         }

--- a/modules/module-billing-payments/src/Support/CustomerReference.php
+++ b/modules/module-billing-payments/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Payments\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $hasTeam = Schema::hasColumn('customers', 'team_id');
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($hasTeam ? ['team_id'] : ['id']);
+        if ($customer === null || ($hasTeam && $customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/modules/module-billing-provisioning-api/src/Http/Controllers/ProvisioningOperationController.php
+++ b/modules/module-billing-provisioning-api/src/Http/Controllers/ProvisioningOperationController.php
@@ -34,14 +34,16 @@ final class ProvisioningOperationController extends Controller
 
     public function queue(Request $request, ProvisionedService $provisionedService, QueueProvisioningOperation $queue): JsonResponse
     {
+        $provisionedService = $this->forCurrentTeam($request, $provisionedService);
         Gate::authorize('update', $provisionedService);
         $data = $request->validate(['operation' => ['required', 'in:provision,deprovision,poll,reconcile,rollback'], 'payload' => ['sometimes', 'array']]);
 
         return response()->json(['data' => $queue->execute($provisionedService, $data['operation'], $data['payload'] ?? [])], 202);
     }
 
-    public function reconcile(ProvisionedService $provisionedService, ReconcileProvisionedService $reconcile): JsonResponse
+    public function reconcile(Request $request, ProvisionedService $provisionedService, ReconcileProvisionedService $reconcile): JsonResponse
     {
+        $provisionedService = $this->forCurrentTeam($request, $provisionedService);
         Gate::authorize('update', $provisionedService);
 
         return response()->json(['data' => $reconcile->execute($provisionedService)]);
@@ -53,5 +55,10 @@ final class ProvisioningOperationController extends Controller
         abort_if($team === null, 403, 'A current team is required.');
 
         return (int) $team;
+    }
+
+    private function forCurrentTeam(Request $request, ProvisionedService $service): ProvisionedService
+    {
+        return ProvisionedService::query()->whereKey($service->getKey())->where('team_id', $this->team($request))->firstOrFail();
     }
 }

--- a/modules/module-billing-provisioning/src/Actions/CreateProvisionedService.php
+++ b/modules/module-billing-provisioning/src/Actions/CreateProvisionedService.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Provisioning\Enums\ProvisioningState;
 use Liberu\Billing\Provisioning\Models\ProvisionedService;
+use Liberu\Billing\Provisioning\Support\CustomerReference;
 
 final class CreateProvisionedService
 {
@@ -18,6 +19,9 @@ final class CreateProvisionedService
         if ($provider === '') {
             throw new \InvalidArgumentException('A provisioning provider is required.');
         }
+
+        $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam(app('db'), $attributes['customer_id'] ?? null, $teamId);
 
         $subscriptionId = $attributes['subscription_id'] ?? null;
         if ($subscriptionId !== null && Schema::hasTable('billing_subscriptions')) {
@@ -30,8 +34,8 @@ final class CreateProvisionedService
         }
 
         return DB::transaction(fn (): ProvisionedService => ProvisionedService::query()->create([
-            'team_id' => $attributes['team_id'] ?? null,
-            'customer_id' => $attributes['customer_id'] ?? null,
+            'team_id' => $teamId,
+            'customer_id' => $customerId,
             'subscription_id' => $subscriptionId,
             'provider' => $provider,
             'external_id' => $attributes['external_id'] ?? null,

--- a/modules/module-billing-provisioning/src/Actions/CreateProvisionedService.php
+++ b/modules/module-billing-provisioning/src/Actions/CreateProvisionedService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\Billing\Provisioning\Actions;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Provisioning\Enums\ProvisioningState;
 use Liberu\Billing\Provisioning\Models\ProvisionedService;
 
@@ -18,10 +19,20 @@ final class CreateProvisionedService
             throw new \InvalidArgumentException('A provisioning provider is required.');
         }
 
+        $subscriptionId = $attributes['subscription_id'] ?? null;
+        if ($subscriptionId !== null && Schema::hasTable('billing_subscriptions')) {
+            $subscriptionTeam = DB::table('billing_subscriptions')->where('id', (int) $subscriptionId)->value('team_id');
+            if ($subscriptionTeam === null || (int) $subscriptionTeam !== (int) ($attributes['team_id'] ?? 0)) {
+                throw new \InvalidArgumentException('Provisioning subscription reference is invalid.');
+            }
+        } elseif ($subscriptionId !== null) {
+            throw new \InvalidArgumentException('Provisioning subscription reference is invalid.');
+        }
+
         return DB::transaction(fn (): ProvisionedService => ProvisionedService::query()->create([
             'team_id' => $attributes['team_id'] ?? null,
             'customer_id' => $attributes['customer_id'] ?? null,
-            'subscription_id' => $attributes['subscription_id'] ?? null,
+            'subscription_id' => $subscriptionId,
             'provider' => $provider,
             'external_id' => $attributes['external_id'] ?? null,
             'state' => $attributes['state'] ?? ProvisioningState::Pending,

--- a/modules/module-billing-provisioning/src/Actions/ReconcileProvisionedService.php
+++ b/modules/module-billing-provisioning/src/Actions/ReconcileProvisionedService.php
@@ -14,9 +14,10 @@ final readonly class ReconcileProvisionedService
     public function execute(ProvisionedService $service): ProvisionedService
     {
         return $this->database->transaction(function () use ($service): ProvisionedService {
-            $service->update(['last_reconciled_at' => now()]);
+            $locked = ProvisionedService::query()->lockForUpdate()->findOrFail($service->getKey());
+            $locked->update(['last_reconciled_at' => now()]);
 
-            return $service->refresh();
+            return $locked->refresh();
         });
     }
 }

--- a/modules/module-billing-provisioning/src/Actions/RunProvisioningOperation.php
+++ b/modules/module-billing-provisioning/src/Actions/RunProvisioningOperation.php
@@ -15,14 +15,27 @@ final readonly class RunProvisioningOperation
 
     public function execute(ProvisioningOperation $operation): ProvisioningOperation
     {
-        if ($operation->status === 'completed') {
-            return $operation;
+        $claimed = $this->database->transaction(function () use ($operation): ?ProvisioningOperation {
+            $locked = ProvisioningOperation::query()->lockForUpdate()->findOrFail($operation->getKey());
+            if ($locked->status === 'completed') {
+                return null;
+            }
+            if ($locked->status === 'running') {
+                throw new \LogicException('Provisioning operation is already running.');
+            }
+
+            $locked->update(['status' => 'running', 'attempts' => ((int) $locked->attempts) + 1]);
+
+            return $locked->load('service');
+        });
+
+        if ($claimed === null) {
+            return $operation->refresh();
         }
 
+        $operation = $claimed;
         $service = $operation->service;
         $driver = $this->drivers->resolve((string) $service->provider);
-
-        $operation->update(['status' => 'running', 'attempts' => ((int) $operation->attempts) + 1]);
 
         try {
             $result = match ($operation->operation) {

--- a/modules/module-billing-provisioning/src/Actions/TransitionProvisionedService.php
+++ b/modules/module-billing-provisioning/src/Actions/TransitionProvisionedService.php
@@ -20,9 +20,14 @@ final readonly class TransitionProvisionedService
         }
 
         return $this->database->transaction(function () use ($service, $state, $error): ProvisionedService {
-            $service->forceFill(['state' => $state, 'last_error' => $error])->save();
+            $locked = ProvisionedService::query()->lockForUpdate()->findOrFail($service->getKey());
+            if (! $this->allowed($locked->state, $state)) {
+                throw new InvalidArgumentException("Invalid provisioning transition from [{$locked->state->value}] to [{$state->value}].");
+            }
 
-            return $service->refresh();
+            $locked->forceFill(['state' => $state, 'last_error' => $error])->save();
+
+            return $locked->refresh();
         });
     }
 

--- a/modules/module-billing-provisioning/src/Support/CustomerReference.php
+++ b/modules/module-billing-provisioning/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Provisioning\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $hasTeam = Schema::hasColumn('customers', 'team_id');
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($hasTeam ? ['team_id'] : ['id']);
+        if ($customer === null || ($hasTeam && $customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/modules/module-billing-reporting/src/Actions/CalculateReportingMetric.php
+++ b/modules/module-billing-reporting/src/Actions/CalculateReportingMetric.php
@@ -87,7 +87,7 @@ final readonly class CalculateReportingMetric
         }
         $query = $this->database->table('billing_invoices')->where('team_id', $teamId)->when($currency !== null, fn ($query) => $query->where('currency', $currency));
         if ($kind === 'aging') {
-            return (float) $query->whereIn('status', ['finalized', 'draft'])->whereNotNull('due_at')->where('due_at', '<=', $at)->sum('total_minor');
+            return (float) $query->where('status', 'finalized')->whereNotNull('due_at')->where('due_at', '<=', $at)->sum('total_minor');
         }
 
         $column = $kind === 'tax' ? 'tax_minor' : 'total_minor';

--- a/modules/module-billing-subscriptions-api/src/Http/Controllers/SubscriptionController.php
+++ b/modules/module-billing-subscriptions-api/src/Http/Controllers/SubscriptionController.php
@@ -50,29 +50,33 @@ final class SubscriptionController extends Controller
         return response()->json(['data' => $this->resource($activate->execute($data))], 201);
     }
 
-    public function renew(Subscription $subscription, RenewSubscription $renew): JsonResponse
+    public function renew(Request $request, Subscription $subscription, RenewSubscription $renew): JsonResponse
     {
+        $subscription = $this->forCurrentTeam($request, $subscription);
         Gate::authorize('update', $subscription);
 
         return response()->json(['data' => $this->resource($renew->execute($subscription))]);
     }
 
-    public function pause(Subscription $subscription, PauseSubscription $pause): JsonResponse
+    public function pause(Request $request, Subscription $subscription, PauseSubscription $pause): JsonResponse
     {
+        $subscription = $this->forCurrentTeam($request, $subscription);
         Gate::authorize('update', $subscription);
 
         return response()->json(['data' => $this->resource($pause->execute($subscription))]);
     }
 
-    public function cancel(Subscription $subscription, CancelSubscription $cancel): JsonResponse
+    public function cancel(Request $request, Subscription $subscription, CancelSubscription $cancel): JsonResponse
     {
+        $subscription = $this->forCurrentTeam($request, $subscription);
         Gate::authorize('update', $subscription);
 
         return response()->json(['data' => $this->resource($cancel->execute($subscription))]);
     }
 
-    public function resume(Subscription $subscription, ResumeSubscription $resume): JsonResponse
+    public function resume(Request $request, Subscription $subscription, ResumeSubscription $resume): JsonResponse
     {
+        $subscription = $this->forCurrentTeam($request, $subscription);
         Gate::authorize('update', $subscription);
 
         return response()->json(['data' => $this->resource($resume->execute($subscription))]);
@@ -80,6 +84,7 @@ final class SubscriptionController extends Controller
 
     public function changePlan(Request $request, Subscription $subscription, ChangeSubscriptionPlan $change): JsonResponse
     {
+        $subscription = $this->forCurrentTeam($request, $subscription);
         Gate::authorize('update', $subscription);
         $data = $request->validate(['pricing_plan_id' => ['nullable', 'integer', 'min:1']]);
 
@@ -88,6 +93,7 @@ final class SubscriptionController extends Controller
 
     public function entitlements(Request $request, Subscription $subscription, UpdateEntitlementState $update): JsonResponse
     {
+        $subscription = $this->forCurrentTeam($request, $subscription);
         Gate::authorize('update', $subscription);
         $data = $request->validate(['entitlement_state' => ['required', 'array']]);
 
@@ -112,5 +118,12 @@ final class SubscriptionController extends Controller
                 'entitlement_state' => $subscription->entitlement_state ?? [],
             ],
         ];
+    }
+
+    private function forCurrentTeam(Request $request, Subscription $subscription): Subscription
+    {
+        $teamId = data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id');
+
+        return Subscription::query()->whereKey($subscription->getKey())->where('team_id', $teamId)->firstOrFail();
     }
 }

--- a/modules/module-billing-subscriptions-livewire/src/Components/SubscriptionList.php
+++ b/modules/module-billing-subscriptions-livewire/src/Components/SubscriptionList.php
@@ -76,7 +76,8 @@ final class SubscriptionList extends Component
 
     private function authorizedSubscription(int $subscriptionId): Subscription
     {
-        $subscription = Subscription::query()->findOrFail($subscriptionId);
+        $teamId = data_get(auth()->user(), 'current_team_id') ?? data_get(auth()->user(), 'currentTeam.id');
+        $subscription = Subscription::query()->whereKey($subscriptionId)->where('team_id', $teamId)->firstOrFail();
         Gate::authorize('update', $subscription);
 
         return $subscription;

--- a/modules/module-billing-subscriptions/src/Actions/ActivateSubscription.php
+++ b/modules/module-billing-subscriptions/src/Actions/ActivateSubscription.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 use Liberu\Billing\Subscriptions\Events\SubscriptionActivated;
 use Liberu\Billing\Subscriptions\Models\Subscription;
+use Liberu\Billing\Subscriptions\Support\CustomerReference;
 
 final readonly class ActivateSubscription
 {
@@ -27,6 +28,7 @@ final readonly class ActivateSubscription
 
         $pricingPlanId = $attributes['pricing_plan_id'] ?? null;
         $teamId = $attributes['team_id'] ?? null;
+        $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $teamId);
 
         if ($pricingPlanId !== null && Schema::hasTable('billing_pricing_plans')) {
             $pricingPlan = $this->database->table('billing_pricing_plans')
@@ -40,10 +42,10 @@ final readonly class ActivateSubscription
             throw new \InvalidArgumentException('Subscription pricing plan reference is invalid.');
         }
 
-        $subscription = $this->database->transaction(function () use ($attributes, $startsAt, $trialEndsAt, $trialDays, $pricingPlanId): Subscription {
+        $subscription = $this->database->transaction(function () use ($attributes, $startsAt, $trialEndsAt, $trialDays, $pricingPlanId, $customerId): Subscription {
             return Subscription::query()->create([
                 'team_id' => $attributes['team_id'] ?? null,
-                'customer_id' => $attributes['customer_id'] ?? null,
+                'customer_id' => $customerId,
                 'pricing_plan_id' => $pricingPlanId,
                 'status' => $trialDays > 0 ? SubscriptionStatus::Trialing : SubscriptionStatus::Active,
                 'starts_at' => $startsAt,

--- a/modules/module-billing-subscriptions/src/Actions/ActivateSubscription.php
+++ b/modules/module-billing-subscriptions/src/Actions/ActivateSubscription.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\Billing\Subscriptions\Actions;
 
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 use Liberu\Billing\Subscriptions\Events\SubscriptionActivated;
 use Liberu\Billing\Subscriptions\Models\Subscription;
@@ -24,11 +25,26 @@ final readonly class ActivateSubscription
             throw new \InvalidArgumentException('A team or customer is required.');
         }
 
-        $subscription = $this->database->transaction(function () use ($attributes, $startsAt, $trialEndsAt, $trialDays): Subscription {
+        $pricingPlanId = $attributes['pricing_plan_id'] ?? null;
+        $teamId = $attributes['team_id'] ?? null;
+
+        if ($pricingPlanId !== null && Schema::hasTable('billing_pricing_plans')) {
+            $pricingPlan = $this->database->table('billing_pricing_plans')
+                ->where('id', (int) $pricingPlanId)
+                ->first(['team_id']);
+
+            if ($pricingPlan === null || ($pricingPlan->team_id !== null && ($teamId === null || (int) $pricingPlan->team_id !== (int) $teamId))) {
+                throw new \InvalidArgumentException('Subscription pricing plan reference is invalid.');
+            }
+        } elseif ($pricingPlanId !== null) {
+            throw new \InvalidArgumentException('Subscription pricing plan reference is invalid.');
+        }
+
+        $subscription = $this->database->transaction(function () use ($attributes, $startsAt, $trialEndsAt, $trialDays, $pricingPlanId): Subscription {
             return Subscription::query()->create([
                 'team_id' => $attributes['team_id'] ?? null,
                 'customer_id' => $attributes['customer_id'] ?? null,
-                'pricing_plan_id' => $attributes['pricing_plan_id'] ?? null,
+                'pricing_plan_id' => $pricingPlanId,
                 'status' => $trialDays > 0 ? SubscriptionStatus::Trialing : SubscriptionStatus::Active,
                 'starts_at' => $startsAt,
                 'trial_ends_at' => $trialEndsAt,

--- a/modules/module-billing-subscriptions/src/Actions/CancelSubscription.php
+++ b/modules/module-billing-subscriptions/src/Actions/CancelSubscription.php
@@ -20,9 +20,14 @@ final readonly class CancelSubscription
         }
 
         $cancelled = $this->database->transaction(function () use ($subscription): Subscription {
-            $subscription->update(['status' => SubscriptionStatus::Cancelled, 'cancelled_at' => now(), 'auto_renew' => false, 'entitlement_state' => array_merge($subscription->entitlement_state ?? [], ['active' => false])]);
+            $locked = Subscription::query()->lockForUpdate()->findOrFail($subscription->getKey());
+            if ($locked->status === SubscriptionStatus::Cancelled) {
+                return $locked;
+            }
 
-            return $subscription->refresh();
+            $locked->update(['status' => SubscriptionStatus::Cancelled, 'cancelled_at' => now(), 'auto_renew' => false, 'entitlement_state' => array_merge($locked->entitlement_state ?? [], ['active' => false])]);
+
+            return $locked->refresh();
         });
         SubscriptionCancelled::dispatch($cancelled);
 

--- a/modules/module-billing-subscriptions/src/Actions/ChangeSubscriptionPlan.php
+++ b/modules/module-billing-subscriptions/src/Actions/ChangeSubscriptionPlan.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\Billing\Subscriptions\Actions;
 
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 use Liberu\Billing\Subscriptions\Events\SubscriptionPlanChanged;
 use Liberu\Billing\Subscriptions\Models\Subscription;
@@ -26,6 +27,18 @@ final readonly class ChangeSubscriptionPlan
             $locked = Subscription::query()->lockForUpdate()->findOrFail($subscription->getKey());
             if (in_array($locked->status, [SubscriptionStatus::Cancelled, SubscriptionStatus::Expired], true)) {
                 throw new \LogicException('A terminal subscription cannot change plans.');
+            }
+
+            if ($pricingPlanId !== null && Schema::hasTable('billing_pricing_plans')) {
+                $pricingPlan = $this->database->table('billing_pricing_plans')
+                    ->where('id', $pricingPlanId)
+                    ->first(['team_id']);
+
+                if ($pricingPlan === null || ($pricingPlan->team_id !== null && ($locked->team_id === null || (int) $pricingPlan->team_id !== (int) $locked->team_id))) {
+                    throw new \InvalidArgumentException('Subscription pricing plan reference is invalid.');
+                }
+            } elseif ($pricingPlanId !== null) {
+                throw new \InvalidArgumentException('Subscription pricing plan reference is invalid.');
             }
 
             $locked->update(['pricing_plan_id' => $pricingPlanId, 'metadata' => array_merge($locked->metadata ?? [], ['plan_changed_at' => now()->toIso8601String()])]);

--- a/modules/module-billing-subscriptions/src/Actions/ChangeSubscriptionPlan.php
+++ b/modules/module-billing-subscriptions/src/Actions/ChangeSubscriptionPlan.php
@@ -23,9 +23,14 @@ final readonly class ChangeSubscriptionPlan
         }
 
         $changed = $this->database->transaction(function () use ($subscription, $pricingPlanId): Subscription {
-            $subscription->update(['pricing_plan_id' => $pricingPlanId, 'metadata' => array_merge($subscription->metadata ?? [], ['plan_changed_at' => now()->toIso8601String()])]);
+            $locked = Subscription::query()->lockForUpdate()->findOrFail($subscription->getKey());
+            if (in_array($locked->status, [SubscriptionStatus::Cancelled, SubscriptionStatus::Expired], true)) {
+                throw new \LogicException('A terminal subscription cannot change plans.');
+            }
 
-            return $subscription->refresh();
+            $locked->update(['pricing_plan_id' => $pricingPlanId, 'metadata' => array_merge($locked->metadata ?? [], ['plan_changed_at' => now()->toIso8601String()])]);
+
+            return $locked->refresh();
         });
 
         SubscriptionPlanChanged::dispatch($changed);

--- a/modules/module-billing-subscriptions/src/Actions/PauseSubscription.php
+++ b/modules/module-billing-subscriptions/src/Actions/PauseSubscription.php
@@ -20,9 +20,14 @@ final readonly class PauseSubscription
         }
 
         $paused = $this->database->transaction(function () use ($subscription): Subscription {
-            $subscription->update(['status' => SubscriptionStatus::Paused, 'paused_at' => now(), 'entitlement_state' => array_merge($subscription->entitlement_state ?? [], ['active' => false])]);
+            $locked = Subscription::query()->lockForUpdate()->findOrFail($subscription->getKey());
+            if (in_array($locked->status, [SubscriptionStatus::Cancelled, SubscriptionStatus::Expired], true)) {
+                throw new \LogicException('A terminal subscription cannot be paused.');
+            }
 
-            return $subscription->refresh();
+            $locked->update(['status' => SubscriptionStatus::Paused, 'paused_at' => now(), 'entitlement_state' => array_merge($locked->entitlement_state ?? [], ['active' => false])]);
+
+            return $locked->refresh();
         });
 
         SubscriptionPaused::dispatch($paused);

--- a/modules/module-billing-subscriptions/src/Actions/RenewSubscription.php
+++ b/modules/module-billing-subscriptions/src/Actions/RenewSubscription.php
@@ -15,24 +15,26 @@ final readonly class RenewSubscription
 
     public function execute(Subscription $subscription, int $periodDays = 30): Subscription
     {
-        if (! $subscription->auto_renew || in_array($subscription->status, [SubscriptionStatus::Cancelled, SubscriptionStatus::Expired], true)) {
-            throw new \LogicException('Subscription cannot be renewed.');
-        }
         if ($periodDays < 1) {
             throw new \InvalidArgumentException('Renewal period must be positive.');
         }
 
         $renewed = $this->database->transaction(function () use ($subscription, $periodDays): Subscription {
-            $base = $subscription->current_period_ends_at?->copy() ?? now();
-            $subscription->update([
+            $locked = Subscription::query()->lockForUpdate()->findOrFail($subscription->getKey());
+            if (! $locked->auto_renew || in_array($locked->status, [SubscriptionStatus::Cancelled, SubscriptionStatus::Expired], true)) {
+                throw new \LogicException('Subscription cannot be renewed.');
+            }
+
+            $base = $locked->current_period_ends_at?->copy() ?? now();
+            $locked->update([
                 'status' => SubscriptionStatus::Active,
                 'current_period_ends_at' => $base->addDays($periodDays),
                 'cancelled_at' => null,
                 'paused_at' => null,
-                'entitlement_state' => array_merge($subscription->entitlement_state ?? [], ['active' => true]),
+                'entitlement_state' => array_merge($locked->entitlement_state ?? [], ['active' => true]),
             ]);
 
-            return $subscription->refresh();
+            return $locked->refresh();
         });
         SubscriptionRenewed::dispatch($renewed);
 

--- a/modules/module-billing-subscriptions/src/Actions/ResumeSubscription.php
+++ b/modules/module-billing-subscriptions/src/Actions/ResumeSubscription.php
@@ -20,13 +20,18 @@ final readonly class ResumeSubscription
         }
 
         $resumed = $this->database->transaction(function () use ($subscription): Subscription {
-            $subscription->update([
+            $locked = Subscription::query()->lockForUpdate()->findOrFail($subscription->getKey());
+            if ($locked->status !== SubscriptionStatus::Paused) {
+                throw new \LogicException('Only paused subscriptions can be resumed.');
+            }
+
+            $locked->update([
                 'status' => SubscriptionStatus::Active,
                 'paused_at' => null,
-                'entitlement_state' => array_merge($subscription->entitlement_state ?? [], ['active' => true]),
+                'entitlement_state' => array_merge($locked->entitlement_state ?? [], ['active' => true]),
             ]);
 
-            return $subscription->refresh();
+            return $locked->refresh();
         });
 
         SubscriptionResumed::dispatch($resumed);

--- a/modules/module-billing-subscriptions/src/Actions/UpdateEntitlementState.php
+++ b/modules/module-billing-subscriptions/src/Actions/UpdateEntitlementState.php
@@ -21,9 +21,14 @@ final readonly class UpdateEntitlementState
         }
 
         $updated = $this->database->transaction(function () use ($subscription, $entitlements): Subscription {
-            $subscription->update(['entitlement_state' => $entitlements]);
+            $locked = Subscription::query()->lockForUpdate()->findOrFail($subscription->getKey());
+            if (in_array($locked->status, [SubscriptionStatus::Cancelled, SubscriptionStatus::Expired], true)) {
+                throw new \LogicException('A terminal subscription cannot change entitlements.');
+            }
 
-            return $subscription->refresh();
+            $locked->update(['entitlement_state' => $entitlements]);
+
+            return $locked->refresh();
         });
 
         SubscriptionEntitlementsUpdated::dispatch($updated);

--- a/modules/module-billing-subscriptions/src/Support/CustomerReference.php
+++ b/modules/module-billing-subscriptions/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Subscriptions\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $hasTeam = Schema::hasColumn('customers', 'team_id');
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($hasTeam ? ['team_id'] : ['id']);
+        if ($customer === null || ($hasTeam && $customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/modules/module-billing-usage-api/src/Http/Controllers/UsageController.php
+++ b/modules/module-billing-usage-api/src/Http/Controllers/UsageController.php
@@ -82,6 +82,7 @@ final class UsageController extends Controller
 
     public function aggregateForMeter(Request $request, Meter $meter, AggregateUsage $aggregate): JsonResponse
     {
+        $meter = $this->forCurrentTeam($request, $meter->getKey());
         Gate::authorize('view', $meter);
 
         return response()->json(['data' => $aggregate->execute((int) $meter->getKey(), $request->integer('customer_id') ?: null)]);
@@ -89,6 +90,7 @@ final class UsageController extends Controller
 
     public function rate(Request $request, Meter $meter, RateUsage $rate, CheckUsageThreshold $threshold): JsonResponse
     {
+        $meter = $this->forCurrentTeam($request, $meter->getKey());
         Gate::authorize('view', $meter);
         $data = $request->validate(['quantity' => ['required', 'numeric', 'min:0']]);
         $quantity = (float) $data['quantity'];
@@ -108,6 +110,13 @@ final class UsageController extends Controller
     private function team(Request $request): int
     {
         return (int) (data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id'));
+    }
+
+    private function forCurrentTeam(Request $request, int $meterId): Meter
+    {
+        $teamId = $this->team($request);
+
+        return Meter::query()->whereKey($meterId)->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $teamId))->firstOrFail();
     }
 
     private function meter(Meter $meter): array

--- a/modules/module-billing-usage/src/Actions/CorrectUsage.php
+++ b/modules/module-billing-usage/src/Actions/CorrectUsage.php
@@ -13,10 +13,19 @@ final readonly class CorrectUsage
 
     public function execute(UsageRecord $record, float $quantity, string $eventKey): UsageRecord
     {
-        if ($quantity == 0.0 || $eventKey === '') {
+        $eventKey = trim($eventKey);
+        if ($quantity == 0.0 || ! is_finite($quantity) || $eventKey === '') {
             throw new \InvalidArgumentException('Correction quantity and event key are invalid.');
         }
 
-        return $this->database->transaction(fn (): UsageRecord => UsageRecord::query()->create(['team_id' => $record->team_id, 'customer_id' => $record->customer_id, 'meter_id' => $record->meter_id, 'event_key' => $eventKey, 'quantity' => $quantity, 'unit_price_minor' => $record->unit_price_minor, 'amount_minor' => (int) round($quantity * (int) $record->unit_price_minor), 'currency' => $record->currency, 'occurred_at' => now(), 'corrects_id' => $record->getKey(), 'metadata' => ['correction' => true]]));
+        return $this->database->transaction(function () use ($record, $quantity, $eventKey): UsageRecord {
+            $source = UsageRecord::query()->lockForUpdate()->findOrFail($record->getKey());
+            $existing = UsageRecord::query()->where('meter_id', $source->meter_id)->where('event_key', $eventKey)->first();
+            if ($existing !== null) {
+                return $existing;
+            }
+
+            return UsageRecord::query()->create(['team_id' => $source->team_id, 'customer_id' => $source->customer_id, 'meter_id' => $source->meter_id, 'event_key' => $eventKey, 'quantity' => $quantity, 'unit_price_minor' => $source->unit_price_minor, 'amount_minor' => (int) round($quantity * (int) $source->unit_price_minor), 'currency' => $source->currency, 'occurred_at' => now(), 'corrects_id' => $source->getKey(), 'metadata' => ['correction' => true]]);
+        });
     }
 }

--- a/modules/module-billing-usage/src/Actions/DefineMeter.php
+++ b/modules/module-billing-usage/src/Actions/DefineMeter.php
@@ -13,11 +13,15 @@ final readonly class DefineMeter
 
     public function execute(array $attributes): Meter
     {
+        $code = strtolower(trim((string) ($attributes['code'] ?? '')));
+        $name = trim((string) ($attributes['name'] ?? $code));
+        $unit = trim((string) ($attributes['unit'] ?? 'unit'));
         $currency = strtoupper((string) ($attributes['currency'] ?? ''));
-        if ((string) ($attributes['code'] ?? '') === '' || ! preg_match('/^[A-Z]{3}$/', $currency) || (int) ($attributes['unit_price_minor'] ?? 0) < 0) {
+        $threshold = $attributes['threshold'] ?? null;
+        if ($code === '' || $name === '' || $unit === '' || ! preg_match('/^[a-z][a-z0-9_.-]*$/', $code) || ! preg_match('/^[A-Z]{3}$/', $currency) || (int) ($attributes['unit_price_minor'] ?? 0) < 0 || ($threshold !== null && (! is_int($threshold) && ! is_float($threshold) && ! is_numeric($threshold) || (float) $threshold < 0))) {
             throw new \InvalidArgumentException('Meter code, currency, and price are invalid.');
         }
 
-        return $this->database->transaction(fn (): Meter => Meter::query()->create(['team_id' => $attributes['team_id'] ?? null, 'name' => $attributes['name'] ?? $attributes['code'], 'code' => $attributes['code'], 'unit' => $attributes['unit'] ?? 'unit', 'unit_price_minor' => $attributes['unit_price_minor'], 'currency' => $currency, 'threshold' => $attributes['threshold'] ?? null, 'active' => true, 'metadata' => $attributes['metadata'] ?? []]));
+        return $this->database->transaction(fn (): Meter => Meter::query()->create(['team_id' => $attributes['team_id'] ?? null, 'name' => $name, 'code' => $code, 'unit' => $unit, 'unit_price_minor' => $attributes['unit_price_minor'], 'currency' => $currency, 'threshold' => $threshold, 'active' => true, 'metadata' => $attributes['metadata'] ?? []]));
     }
 }

--- a/modules/module-billing-usage/src/Actions/IngestUsage.php
+++ b/modules/module-billing-usage/src/Actions/IngestUsage.php
@@ -15,18 +15,26 @@ final readonly class IngestUsage
 
     public function execute(Meter $meter, array $attributes): UsageRecord
     {
-        $key = (string) ($attributes['event_key'] ?? '');
+        $key = trim((string) ($attributes['event_key'] ?? ''));
         $quantity = (float) ($attributes['quantity'] ?? 0);
-        if (! $meter->active || $key === '' || $quantity <= 0) {
+        if ($key === '' || $quantity <= 0 || ! is_finite($quantity)) {
             throw new \InvalidArgumentException('Usage event or quantity is invalid.');
-        }
-        $existing = UsageRecord::query()->where('meter_id', $meter->getKey())->where('event_key', $key)->first();
-        if ($existing) {
-            return $existing;
         }
 
         try {
-            return $this->database->transaction(fn (): UsageRecord => UsageRecord::query()->create(['team_id' => $meter->team_id, 'customer_id' => $attributes['customer_id'] ?? null, 'meter_id' => $meter->getKey(), 'event_key' => $key, 'quantity' => $quantity, 'unit_price_minor' => $meter->unit_price_minor, 'amount_minor' => (int) round($quantity * (int) $meter->unit_price_minor), 'currency' => $meter->currency, 'occurred_at' => $attributes['occurred_at'] ?? now(), 'metadata' => $attributes['metadata'] ?? []]));
+            return $this->database->transaction(function () use ($meter, $attributes, $key, $quantity): UsageRecord {
+                $locked = Meter::query()->lockForUpdate()->findOrFail($meter->getKey());
+                if (! $locked->active) {
+                    throw new \LogicException('Usage cannot be ingested into an inactive meter.');
+                }
+
+                $existing = UsageRecord::query()->where('meter_id', $locked->getKey())->where('event_key', $key)->first();
+                if ($existing !== null) {
+                    return $existing;
+                }
+
+                return UsageRecord::query()->create(['team_id' => $locked->team_id, 'customer_id' => $attributes['customer_id'] ?? null, 'meter_id' => $locked->getKey(), 'event_key' => $key, 'quantity' => $quantity, 'unit_price_minor' => $locked->unit_price_minor, 'amount_minor' => (int) round($quantity * (int) $locked->unit_price_minor), 'currency' => $locked->currency, 'occurred_at' => $attributes['occurred_at'] ?? now(), 'metadata' => $attributes['metadata'] ?? []]);
+            });
         } catch (QueryException $exception) {
             if (! str_contains(strtolower($exception->getMessage()), 'unique')) {
                 throw $exception;

--- a/modules/module-billing-usage/src/Actions/IngestUsage.php
+++ b/modules/module-billing-usage/src/Actions/IngestUsage.php
@@ -8,6 +8,7 @@ use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\QueryException;
 use Liberu\Billing\Usage\Models\Meter;
 use Liberu\Billing\Usage\Models\UsageRecord;
+use Liberu\Billing\Usage\Support\CustomerReference;
 
 final readonly class IngestUsage
 {
@@ -28,12 +29,14 @@ final readonly class IngestUsage
                     throw new \LogicException('Usage cannot be ingested into an inactive meter.');
                 }
 
+                $customerId = CustomerReference::assertBelongsToTeam($this->database, $attributes['customer_id'] ?? null, $locked->team_id);
+
                 $existing = UsageRecord::query()->where('meter_id', $locked->getKey())->where('event_key', $key)->first();
                 if ($existing !== null) {
                     return $existing;
                 }
 
-                return UsageRecord::query()->create(['team_id' => $locked->team_id, 'customer_id' => $attributes['customer_id'] ?? null, 'meter_id' => $locked->getKey(), 'event_key' => $key, 'quantity' => $quantity, 'unit_price_minor' => $locked->unit_price_minor, 'amount_minor' => (int) round($quantity * (int) $locked->unit_price_minor), 'currency' => $locked->currency, 'occurred_at' => $attributes['occurred_at'] ?? now(), 'metadata' => $attributes['metadata'] ?? []]);
+                return UsageRecord::query()->create(['team_id' => $locked->team_id, 'customer_id' => $customerId, 'meter_id' => $locked->getKey(), 'event_key' => $key, 'quantity' => $quantity, 'unit_price_minor' => $locked->unit_price_minor, 'amount_minor' => (int) round($quantity * (int) $locked->unit_price_minor), 'currency' => $locked->currency, 'occurred_at' => $attributes['occurred_at'] ?? now(), 'metadata' => $attributes['metadata'] ?? []]);
             });
         } catch (QueryException $exception) {
             if (! str_contains(strtolower($exception->getMessage()), 'unique')) {

--- a/modules/module-billing-usage/src/Policies/UsagePolicy.php
+++ b/modules/module-billing-usage/src/Policies/UsagePolicy.php
@@ -19,6 +19,13 @@ final class UsagePolicy
         return $user !== null && ($user->tokenCan('billing.usage.write') || $user->can('billing.usage.write'));
     }
 
+    public function view(?Authenticatable $user, Meter $meter): bool
+    {
+        $teamId = data_get($user, 'current_team_id') ?? data_get($user, 'currentTeam.id');
+
+        return $this->viewAny($user) && ($meter->team_id === null || ($teamId !== null && (int) $meter->team_id === (int) $teamId));
+    }
+
     public function update(?Authenticatable $user, Meter $meter): bool
     {
         $teamId = data_get($user, 'current_team_id') ?? data_get($user, 'currentTeam.id');

--- a/modules/module-billing-usage/src/Support/CustomerReference.php
+++ b/modules/module-billing-usage/src/Support/CustomerReference.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Usage\Support;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Schema;
+
+final class CustomerReference
+{
+    public static function assertBelongsToTeam(DatabaseManager $database, mixed $customerId, mixed $teamId): ?int
+    {
+        if ($customerId === null) {
+            return null;
+        }
+
+        if (! Schema::hasTable('customers')) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        $hasTeam = Schema::hasColumn('customers', 'team_id');
+        $customer = $database->table('customers')->where('id', (int) $customerId)->first($hasTeam ? ['team_id'] : ['id']);
+        if ($customer === null || ($hasTeam && $customer->team_id !== null && ($teamId === null || (int) $customer->team_id !== (int) $teamId))) {
+            throw new \InvalidArgumentException('Customer reference is invalid.');
+        }
+
+        return (int) $customerId;
+    }
+}

--- a/tests/Feature/Api/BillingCatalogTenantScopingTest.php
+++ b/tests/Feature/Api/BillingCatalogTenantScopingTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Catalog\Models\Plan;
+use Tests\TestCase;
+
+class BillingCatalogTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_catalog_record_lifecycle_cannot_access_another_team_record(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $plan = Plan::query()->create([
+            'team_id' => $otherTeam->id,
+            'name' => 'Other team plan',
+            'code' => 'OTHER-PLAN',
+            'status' => 'draft',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->patchJson('/api/v1/billing/catalog/plans/'.$plan->getKey().'/lifecycle', [
+            'status' => 'active',
+        ])->assertNotFound();
+
+        $this->assertDatabaseHas('billing_catalog_plans', [
+            'id' => $plan->getKey(),
+            'team_id' => $otherTeam->id,
+            'status' => 'draft',
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingCollectionsTenantScopingTest.php
+++ b/tests/Feature/Api/BillingCollectionsTenantScopingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Collections\Models\CollectionCase;
+use Tests\TestCase;
+
+class BillingCollectionsTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_case_mutations_cannot_access_another_team_case(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $case = CollectionCase::query()->create([
+            'team_id' => $otherTeam->id,
+            'type' => 'retry',
+            'status' => 'open',
+            'amount_minor' => 100,
+            'currency' => 'USD',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/collections/'.$case->getKey().'/recover')
+            ->assertNotFound();
+
+        $this->assertDatabaseHas('billing_collection_cases', [
+            'id' => $case->getKey(), 'team_id' => $otherTeam->id, 'status' => 'open',
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingCommunicationsTenantScopingTest.php
+++ b/tests/Feature/Api/BillingCommunicationsTenantScopingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Communications\Models\CommunicationService;
+use Tests\TestCase;
+
+class BillingCommunicationsTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_number_provisioning_cannot_attach_another_team_service(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $service = CommunicationService::query()->create([
+            'team_id' => $otherTeam->id,
+            'name' => 'Other team service',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/communications/numbers', [
+            'number' => '+15555550100',
+            'service_id' => $service->getKey(),
+        ])->assertNotFound();
+
+        $this->assertDatabaseMissing('billing_communication_numbers', [
+            'number' => '+15555550100',
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingDomainsTenantScopingTest.php
+++ b/tests/Feature/Api/BillingDomainsTenantScopingTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Domains\Models\Domain;
+use Tests\TestCase;
+
+class BillingDomainsTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_domain_reads_and_mutations_cannot_access_another_team_domain(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $domain = Domain::query()->create([
+            'team_id' => $otherTeam->id,
+            'name' => 'other.example.test',
+            'status' => 'available',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->getJson('/api/v1/billing/domains/'.$domain->getKey())->assertNotFound();
+        $this->postJson('/api/v1/billing/domains/'.$domain->getKey().'/renew')->assertNotFound();
+
+        $this->assertDatabaseHas('billing_domains_records', [
+            'id' => $domain->getKey(), 'team_id' => $otherTeam->id, 'status' => 'available',
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingHostingTenantScopingTest.php
+++ b/tests/Feature/Api/BillingHostingTenantScopingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Hosting\Models\HostingAccount;
+use Liberu\Billing\Hosting\Models\HostingCapability;
+use Tests\TestCase;
+
+class BillingHostingTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_capability_lifecycle_cannot_access_another_team_capability(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $capability = HostingCapability::query()->create([
+            'team_id' => $otherTeam->id,
+            'type' => 'plan',
+            'name' => 'Other team plan',
+            'status' => 'pending',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->patchJson('/api/v1/billing/hosting/capabilities/'.$capability->getKey().'/lifecycle', [
+            'status' => 'active',
+        ])->assertNotFound();
+    }
+
+    public function test_capability_cannot_attach_another_team_account(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $account = HostingAccount::query()->create([
+            'team_id' => $otherTeam->id,
+            'name' => 'Other team account',
+            'status' => 'active',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/hosting/capabilities', [
+            'type' => 'plan',
+            'name' => 'Foreign account capability',
+            'hosting_account_id' => $account->getKey(),
+        ])->assertNotFound();
+
+        $this->assertDatabaseMissing('billing_hosting_capabilities', [
+            'name' => 'Foreign account capability',
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingInvoicingTenantScopingTest.php
+++ b/tests/Feature/Api/BillingInvoicingTenantScopingTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Invoicing\Actions\CreateInvoice;
+use Tests\TestCase;
+
+class BillingInvoicingTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_invoice_mutations_cannot_access_another_team_invoice(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $invoice = app(CreateInvoice::class)->execute([
+            'team_id' => $otherTeam->id,
+            'currency' => 'USD',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/invoicing/'.$invoice->getKey().'/finalize')
+            ->assertNotFound();
+
+        $this->assertDatabaseHas('billing_invoices', [
+            'id' => $invoice->getKey(), 'team_id' => $otherTeam->id, 'status' => 'draft',
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingOrdersTenantScopingTest.php
+++ b/tests/Feature/Api/BillingOrdersTenantScopingTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use Liberu\Billing\Orders\Models\Cart;
+use Liberu\Billing\Orders\Models\Order;
 use Tests\TestCase;
 
 class BillingOrdersTenantScopingTest extends TestCase
@@ -34,5 +35,31 @@ class BillingOrdersTenantScopingTest extends TestCase
         $this->assertDatabaseHas('billing_order_carts', [
             'id' => $cart->getKey(), 'team_id' => $otherTeam->id, 'status' => 'open',
         ]);
+    }
+
+    public function test_order_mutations_cannot_access_another_team_order(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $order = Order::query()->create([
+            'team_id' => $otherTeam->id,
+            'order_number' => 'ORD-FOREIGN',
+            'currency' => 'USD',
+            'subtotal_minor' => 100,
+            'discount_minor' => 0,
+            'tax_minor' => 0,
+            'total_minor' => 100,
+            'status' => 'approved',
+            'fraud_status' => 'not_required',
+        ]);
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/orders/'.$order->getKey().'/fraud-review', [
+            'fraud_status' => 'blocked',
+        ])->assertNotFound();
+        $this->postJson('/api/v1/billing/orders/'.$order->getKey().'/change-orders', [
+            'reason' => 'Unauthorized change',
+        ])->assertNotFound();
     }
 }

--- a/tests/Feature/Api/BillingOrdersTenantScopingTest.php
+++ b/tests/Feature/Api/BillingOrdersTenantScopingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Orders\Models\Cart;
+use Tests\TestCase;
+
+class BillingOrdersTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cart_checkout_cannot_access_another_team_cart(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $cart = Cart::query()->create([
+            'team_id' => $otherTeam->id,
+            'currency' => 'USD',
+            'items' => [],
+            'status' => 'open',
+        ]);
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/orders/carts/'.$cart->getKey().'/checkout', [
+            'subtotal_minor' => 100,
+        ])->assertNotFound();
+
+        $this->assertDatabaseHas('billing_order_carts', [
+            'id' => $cart->getKey(), 'team_id' => $otherTeam->id, 'status' => 'open',
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingPaymentsTenantScopingTest.php
+++ b/tests/Feature/Api/BillingPaymentsTenantScopingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Payments\Models\Payment;
+use Tests\TestCase;
+
+class BillingPaymentsTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_payment_mutations_cannot_access_another_team_payment(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $payment = Payment::query()->create([
+            'team_id' => $otherTeam->id,
+            'amount_minor' => 100,
+            'currency' => 'USD',
+            'status' => 'pending',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/payments/'.$payment->getKey().'/reconcile', [
+            'provider_reference' => 'external-1',
+        ])->assertNotFound();
+
+        $this->assertDatabaseMissing('billing_payment_reconciliations', [
+            'payment_id' => $payment->getKey(),
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingPaymentsTenantScopingTest.php
+++ b/tests/Feature/Api/BillingPaymentsTenantScopingTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use Liberu\Billing\Payments\Models\Payment;
+use Liberu\Billing\Payments\Models\PaymentMethod;
 use Tests\TestCase;
 
 class BillingPaymentsTenantScopingTest extends TestCase
@@ -32,6 +33,28 @@ class BillingPaymentsTenantScopingTest extends TestCase
 
         $this->assertDatabaseMissing('billing_payment_reconciliations', [
             'payment_id' => $payment->getKey(),
+        ]);
+    }
+
+    public function test_mandate_cannot_attach_another_team_payment_method(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $method = PaymentMethod::query()->create([
+            'team_id' => $otherTeam->id,
+            'type' => 'card',
+            'provider' => 'gateway',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/payments/mandates', [
+            'payment_method_id' => $method->getKey(),
+            'provider' => 'gateway',
+        ])->assertNotFound();
+
+        $this->assertDatabaseMissing('billing_payment_mandates', [
+            'payment_method_id' => $method->getKey(),
         ]);
     }
 }

--- a/tests/Feature/Api/BillingPricingTenantScopingTest.php
+++ b/tests/Feature/Api/BillingPricingTenantScopingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Pricing\Models\PricingDiscount;
+use Liberu\Billing\Pricing\Models\PricingPlan;
+use Tests\TestCase;
+
+class BillingPricingTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_discount_redemption_cannot_access_another_team_discount(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $discount = PricingDiscount::query()->create([
+            'team_id' => $otherTeam->id,
+            'code' => 'OTHER-TEAM',
+            'kind' => 'fixed',
+            'value' => 100,
+            'active' => true,
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/pricing/discounts/'.$discount->getKey().'/redeem')
+            ->assertNotFound();
+
+        $this->assertDatabaseHas('billing_pricing_discounts', [
+            'id' => $discount->getKey(),
+            'team_id' => $otherTeam->id,
+            'redemptions' => 0,
+        ]);
+    }
+
+    public function test_pricing_snapshot_cannot_access_another_team_plan(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $plan = PricingPlan::query()->create([
+            'team_id' => $otherTeam->id,
+            'name' => 'Other team plan',
+            'pricing_model' => 'one_time',
+            'currency' => 'USD',
+            'unit_amount_minor' => 100,
+            'status' => 'draft',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/pricing/plans/'.$plan->getKey().'/snapshot')
+            ->assertNotFound();
+
+        $this->assertDatabaseMissing('billing_pricing_snapshots', [
+            'pricing_plan_id' => $plan->getKey(),
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingProvisioningTenantScopingTest.php
+++ b/tests/Feature/Api/BillingProvisioningTenantScopingTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use Liberu\Billing\Provisioning\Models\ProvisionedService;
+use Liberu\Billing\Subscriptions\Models\Subscription;
 use Tests\TestCase;
 
 class BillingProvisioningTenantScopingTest extends TestCase
@@ -31,6 +32,30 @@ class BillingProvisioningTenantScopingTest extends TestCase
 
         $this->assertDatabaseMissing('billing_provisioning_operations', [
             'provisioned_service_id' => $service->getKey(),
+        ]);
+    }
+
+    public function test_provisioned_service_cannot_reference_another_team_subscription(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $subscription = Subscription::query()->create([
+            'team_id' => $otherTeam->id,
+            'status' => 'active',
+            'starts_at' => now(),
+            'auto_renew' => true,
+            'entitlement_state' => [],
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/provisioning/services', [
+            'subscription_id' => $subscription->getKey(),
+            'provider' => 'test',
+        ])->assertNotFound();
+
+        $this->assertDatabaseMissing('billing_provisioned_services', [
+            'subscription_id' => $subscription->getKey(),
         ]);
     }
 }

--- a/tests/Feature/Api/BillingProvisioningTenantScopingTest.php
+++ b/tests/Feature/Api/BillingProvisioningTenantScopingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Provisioning\Models\ProvisionedService;
+use Tests\TestCase;
+
+class BillingProvisioningTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_provisioning_mutations_cannot_access_another_team_service(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $service = ProvisionedService::query()->create([
+            'team_id' => $otherTeam->id,
+            'provider' => 'test',
+            'state' => 'pending',
+            'metadata' => [],
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/provisioning/'.$service->getKey().'/reconcile')
+            ->assertNotFound();
+
+        $this->assertDatabaseMissing('billing_provisioning_operations', [
+            'provisioned_service_id' => $service->getKey(),
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingSubscriptionsTenantScopingTest.php
+++ b/tests/Feature/Api/BillingSubscriptionsTenantScopingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Subscriptions\Models\Subscription;
+use Tests\TestCase;
+
+class BillingSubscriptionsTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_subscription_mutations_cannot_access_another_team_subscription(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $subscription = Subscription::query()->create([
+            'team_id' => $otherTeam->id,
+            'status' => 'active',
+            'starts_at' => now(),
+            'auto_renew' => true,
+            'entitlement_state' => [],
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/subscriptions/'.$subscription->getKey().'/cancel')
+            ->assertNotFound();
+
+        $this->assertDatabaseHas('billing_subscriptions', [
+            'id' => $subscription->getKey(), 'team_id' => $otherTeam->id, 'status' => 'active',
+        ]);
+    }
+}

--- a/tests/Feature/Api/BillingUsageTenantScopingTest.php
+++ b/tests/Feature/Api/BillingUsageTenantScopingTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Liberu\Billing\Usage\Models\Meter;
+use Tests\TestCase;
+
+class BillingUsageTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_meter_aggregate_cannot_access_another_team_meter(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $meter = Meter::query()->create([
+            'team_id' => $otherTeam->id,
+            'name' => 'Other team meter',
+            'code' => 'OTHER-METER',
+            'unit' => 'seat',
+            'unit_price_minor' => 100,
+            'currency' => 'USD',
+            'active' => true,
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->getJson('/api/v1/billing/usage/meters/'.$meter->getKey().'/aggregate')
+            ->assertNotFound();
+    }
+
+    public function test_meter_rate_cannot_access_another_team_meter(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $meter = Meter::query()->create([
+            'team_id' => $otherTeam->id,
+            'name' => 'Other team meter',
+            'code' => 'OTHER-METER',
+            'unit' => 'seat',
+            'unit_price_minor' => 100,
+            'currency' => 'USD',
+            'active' => true,
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $this->postJson('/api/v1/billing/usage/meters/'.$meter->getKey().'/rate', ['quantity' => 2])
+            ->assertNotFound();
+    }
+}

--- a/tests/Feature/BillingHostingTest.php
+++ b/tests/Feature/BillingHostingTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Liberu\Billing\Hosting\Actions\CreateHostingAccount;
 use Liberu\Billing\Hosting\Actions\TransitionHostingAccount;
 use Liberu\Billing\Hosting\Actions\TransitionHostingCapability;
 use Liberu\Billing\Hosting\Contracts\HostingDriver;
@@ -64,4 +65,9 @@ it('normalizes hosting driver keys for registration and lookup', function (): vo
         ->and($registry->keys())->toBe(['cpanel'])
         ->and(fn () => $registry->register($driver))
         ->toThrow(InvalidArgumentException::class, 'Hosting driver keys must be non-empty and unique.');
+});
+
+it('rejects hosting accounts with an invalid initial lifecycle status', function (): void {
+    expect(fn () => app(CreateHostingAccount::class)->handle(1, ['name' => 'invalid-hosting', 'status' => 'unknown']))
+        ->toThrow(InvalidArgumentException::class, 'A team and name are required.');
 });

--- a/tests/Feature/BillingHostingTest.php
+++ b/tests/Feature/BillingHostingTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Liberu\Billing\Hosting\Actions\TransitionHostingAccount;
+use Liberu\Billing\Hosting\Actions\TransitionHostingCapability;
 use Liberu\Billing\Hosting\Models\HostingAccount;
+use Liberu\Billing\Hosting\Models\HostingCapability;
 
 it('does not reactivate cancelled hosting accounts', function (): void {
     $account = HostingAccount::query()->create([
@@ -12,4 +14,19 @@ it('does not reactivate cancelled hosting accounts', function (): void {
 
     expect(fn () => app(TransitionHostingAccount::class)->handle($account, 'active'))
         ->toThrow(InvalidArgumentException::class, 'Cancelled hosting accounts cannot be reactivated.');
+});
+
+it('does not reactivate hosting capabilities after their persisted state becomes cancelled', function (): void {
+    $capability = HostingCapability::query()->create([
+        'team_id' => 1,
+        'name' => 'SSL certificate',
+        'type' => 'ssl',
+        'status' => 'pending',
+        'configuration' => [],
+    ]);
+    $capability->refresh();
+    HostingCapability::query()->whereKey($capability->getKey())->update(['status' => 'cancelled']);
+
+    expect(fn () => app(TransitionHostingCapability::class)->handle($capability, 'active'))
+        ->toThrow(InvalidArgumentException::class, 'Cancelled hosting capabilities cannot be reactivated.');
 });

--- a/tests/Feature/BillingHostingTest.php
+++ b/tests/Feature/BillingHostingTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Liberu\Billing\Hosting\Actions\TransitionHostingAccount;
+use Liberu\Billing\Hosting\Models\HostingAccount;
+
+it('does not reactivate cancelled hosting accounts', function (): void {
+    $account = HostingAccount::query()->create([
+        'team_id' => 1,
+        'name' => 'example-hosting',
+        'status' => 'cancelled',
+    ]);
+
+    expect(fn () => app(TransitionHostingAccount::class)->handle($account, 'active'))
+        ->toThrow(InvalidArgumentException::class, 'Cancelled hosting accounts cannot be reactivated.');
+});

--- a/tests/Feature/BillingHostingTest.php
+++ b/tests/Feature/BillingHostingTest.php
@@ -2,8 +2,10 @@
 
 use Liberu\Billing\Hosting\Actions\TransitionHostingAccount;
 use Liberu\Billing\Hosting\Actions\TransitionHostingCapability;
+use Liberu\Billing\Hosting\Contracts\HostingDriver;
 use Liberu\Billing\Hosting\Models\HostingAccount;
 use Liberu\Billing\Hosting\Models\HostingCapability;
+use Liberu\Billing\Hosting\Services\HostingDriverRegistry;
 
 it('does not reactivate cancelled hosting accounts', function (): void {
     $account = HostingAccount::query()->create([
@@ -29,4 +31,37 @@ it('does not reactivate hosting capabilities after their persisted state becomes
 
     expect(fn () => app(TransitionHostingCapability::class)->handle($capability, 'active'))
         ->toThrow(InvalidArgumentException::class, 'Cancelled hosting capabilities cannot be reactivated.');
+});
+
+it('normalizes hosting driver keys for registration and lookup', function (): void {
+    $registry = new HostingDriverRegistry();
+    $driver = new class() implements HostingDriver
+    {
+        public function key(): string
+        {
+            return ' cPanel ';
+        }
+
+        public function provision(array $attributes): array
+        {
+            return [];
+        }
+
+        public function suspend(array $attributes): array
+        {
+            return [];
+        }
+
+        public function terminate(array $attributes): array
+        {
+            return [];
+        }
+    };
+
+    $registry->register($driver);
+
+    expect($registry->resolve('CPANEL'))->toBe($driver)
+        ->and($registry->keys())->toBe(['cpanel'])
+        ->and(fn () => $registry->register($driver))
+        ->toThrow(InvalidArgumentException::class, 'Hosting driver keys must be non-empty and unique.');
 });

--- a/tests/Feature/Livewire/BillingInvoicingTenantScopingTest.php
+++ b/tests/Feature/Livewire/BillingInvoicingTenantScopingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Invoicing\Actions\FinalizeInvoice;
+use Liberu\Billing\Invoicing\Livewire\Components\InvoiceList;
+use Liberu\Billing\Invoicing\Models\Invoice;
+use Tests\TestCase;
+
+class BillingInvoicingTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_invoice_mutation_cannot_access_another_team_invoice(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $invoice = Invoice::query()->create([
+            'team_id' => $otherTeam->id,
+            'status' => 'draft',
+            'currency' => 'USD',
+            'subtotal_minor' => 0,
+            'tax_minor' => 0,
+            'total_minor' => 0,
+        ]);
+
+        $component = app(InvoiceList::class);
+
+        expect(fn () => $component->finalize($invoice->getKey(), app(FinalizeInvoice::class)))
+            ->toThrow(ModelNotFoundException::class);
+
+        $this->assertDatabaseHas('billing_invoices', [
+            'id' => $invoice->getKey(),
+            'team_id' => $otherTeam->id,
+            'status' => 'draft',
+        ]);
+    }
+}

--- a/tests/Feature/Livewire/BillingSubscriptionsTenantScopingTest.php
+++ b/tests/Feature/Livewire/BillingSubscriptionsTenantScopingTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Subscriptions\Actions\CancelSubscription;
+use Liberu\Billing\Subscriptions\Livewire\Components\SubscriptionList;
+use Liberu\Billing\Subscriptions\Models\Subscription;
+use Tests\TestCase;
+
+class BillingSubscriptionsTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_subscription_mutation_cannot_access_another_team_subscription(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $user->update(['current_team_id' => $user->currentTeam->id]);
+        $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+        $subscription = Subscription::query()->create([
+            'team_id' => $otherTeam->id,
+            'status' => 'active',
+            'starts_at' => now(),
+            'auto_renew' => true,
+            'entitlement_state' => [],
+        ]);
+        $component = app(SubscriptionList::class);
+
+        expect(fn () => $component->cancel($subscription->getKey(), app(CancelSubscription::class)))
+            ->toThrow(ModelNotFoundException::class);
+
+        $this->assertDatabaseHas('billing_subscriptions', [
+            'id' => $subscription->getKey(),
+            'team_id' => $otherTeam->id,
+            'status' => 'active',
+        ]);
+    }
+}

--- a/tests/Unit/BillingCatalogTest.php
+++ b/tests/Unit/BillingCatalogTest.php
@@ -3,7 +3,10 @@
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Catalog\Actions\CreateCatalogRecord;
 use Liberu\Billing\Catalog\Actions\CreateProduct;
+use Liberu\Billing\Catalog\Actions\TransitionProductLifecycle;
+use Liberu\Billing\Catalog\Enums\ProductStatus;
 use Liberu\Billing\Catalog\Models\Plan;
+use Liberu\Billing\Catalog\Models\Product;
 use Liberu\Billing\Catalog\Policies\CatalogRecordPolicy;
 use Liberu\Billing\Catalog\Policies\ProductPolicy;
 
@@ -40,4 +43,15 @@ it('requires catalog write access for mutations and enforces team ownership', fu
         ->and(app(CatalogRecordPolicy::class)->create($readUser))->toBeFalse()
         ->and(app(CatalogRecordPolicy::class)->update($writeUser, $plan))->toBeTrue()
         ->and(app(CatalogRecordPolicy::class)->update($writeUser, $otherTeamPlan))->toBeFalse();
+});
+
+it('does not reopen a product after its persisted state becomes archived', function (): void {
+    $product = app(CreateProduct::class)->execute([
+        'team_id' => 10, 'name' => 'Archived hosting', 'sku' => 'ARCHIVED-HOST', 'base_price_minor' => 1000, 'currency' => 'USD',
+    ]);
+    $product->refresh();
+    Product::query()->whereKey($product->getKey())->update(['status' => 'archived']);
+
+    expect(fn () => app(TransitionProductLifecycle::class)->execute($product, ProductStatus::Active))
+        ->toThrow(InvalidArgumentException::class, 'An archived product cannot be reopened.');
 });

--- a/tests/Unit/BillingCatalogTest.php
+++ b/tests/Unit/BillingCatalogTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
 use Liberu\Billing\Catalog\Actions\CreateCatalogRecord;
 use Liberu\Billing\Catalog\Actions\CreateProduct;
+use Liberu\Billing\Catalog\Actions\TransitionCatalogLifecycle;
 use Liberu\Billing\Catalog\Actions\TransitionProductLifecycle;
+use Liberu\Billing\Catalog\Enums\CatalogStatus;
 use Liberu\Billing\Catalog\Enums\ProductStatus;
 use Liberu\Billing\Catalog\Models\Plan;
 use Liberu\Billing\Catalog\Models\Product;
@@ -54,4 +57,15 @@ it('does not reopen a product after its persisted state becomes archived', funct
 
     expect(fn () => app(TransitionProductLifecycle::class)->execute($product, ProductStatus::Active))
         ->toThrow(InvalidArgumentException::class, 'An archived product cannot be reopened.');
+});
+
+it('does not reopen a catalog record after its persisted state becomes archived', function (): void {
+    $plan = app(CreateCatalogRecord::class)->execute(Plan::class, [
+        'team_id' => 10, 'name' => 'Archived plan', 'code' => 'ARCHIVED-PLAN',
+    ]);
+    $plan->refresh();
+    Plan::query()->whereKey($plan->getKey())->update(['status' => 'archived']);
+
+    expect(fn () => app(TransitionCatalogLifecycle::class)->execute($plan, CatalogStatus::Active))
+        ->toThrow(ValidationException::class, 'Archived catalog records cannot be reactivated.');
 });

--- a/tests/Unit/BillingCollectionsTest.php
+++ b/tests/Unit/BillingCollectionsTest.php
@@ -27,6 +27,12 @@ it('rejects invalid collection amounts', function () {
         ->toThrow(InvalidArgumentException::class);
 });
 
+it('rejects unsupported collection case types', function (): void {
+    expect(fn () => app(OpenCollectionCase::class)->execute([
+        'amount_minor' => 100, 'currency' => 'USD', 'type' => 'unsupported',
+    ]))->toThrow(InvalidArgumentException::class, 'Collection case type is invalid.');
+});
+
 it('records dunning, reminder, and credit-control decisions', function () {
     $case = app(OpenCollectionCase::class)->execute(['team_id' => 10, 'amount_minor' => 1200, 'currency' => 'USD']);
     $nextAction = now()->addDays(3);

--- a/tests/Unit/BillingCollectionsTest.php
+++ b/tests/Unit/BillingCollectionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Collections\Actions\ApplyCreditControl;
 use Liberu\Billing\Collections\Actions\OpenCollectionCase;
@@ -44,6 +46,15 @@ it('rejects a collection case invoice owned by another team', function (): void 
     expect(fn () => app(OpenCollectionCase::class)->execute([
         'team_id' => 10, 'invoice_id' => $invoice->getKey(), 'amount_minor' => 100, 'currency' => 'USD',
     ]))->toThrow(InvalidArgumentException::class, 'Collection invoice reference is invalid.');
+});
+
+it('rejects a collection case customer owned by another team', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+
+    expect(fn () => app(OpenCollectionCase::class)->execute([
+        'team_id' => 10, 'customer_id' => $customerId, 'amount_minor' => 100, 'currency' => 'USD',
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });
 
 it('does not write off a case after its persisted state becomes recovered', function (): void {

--- a/tests/Unit/BillingCollectionsTest.php
+++ b/tests/Unit/BillingCollectionsTest.php
@@ -9,6 +9,7 @@ use Liberu\Billing\Collections\Actions\ScheduleDunning;
 use Liberu\Billing\Collections\Actions\ScheduleReminder;
 use Liberu\Billing\Collections\Actions\SuspendCollectionCase;
 use Liberu\Billing\Collections\Enums\CollectionStatus;
+use Liberu\Billing\Collections\Models\CollectionCase;
 
 uses(RefreshDatabase::class);
 
@@ -41,4 +42,13 @@ it('records dunning, reminder, and credit-control decisions', function () {
     expect($case->type)->toBe('credit_control')
         ->and($case->metadata['credit_control_level'])->toBe('suspend-service')
         ->and($case->reason)->toBe('Repeated non-payment');
+});
+
+it('does not recover a case after its persisted state becomes terminal', function (): void {
+    $case = app(OpenCollectionCase::class)->execute(['team_id' => 10, 'amount_minor' => 1200, 'currency' => 'USD']);
+    $case->refresh();
+    CollectionCase::query()->whereKey($case->getKey())->update(['status' => CollectionStatus::WrittenOff->value]);
+
+    expect(fn () => app(RecoverCollectionCase::class)->execute($case))
+        ->toThrow(LogicException::class, 'This collection case cannot be recovered.');
 });

--- a/tests/Unit/BillingCollectionsTest.php
+++ b/tests/Unit/BillingCollectionsTest.php
@@ -8,6 +8,7 @@ use Liberu\Billing\Collections\Actions\RecoverCollectionCase;
 use Liberu\Billing\Collections\Actions\ScheduleDunning;
 use Liberu\Billing\Collections\Actions\ScheduleReminder;
 use Liberu\Billing\Collections\Actions\SuspendCollectionCase;
+use Liberu\Billing\Collections\Actions\WriteOffCollectionCase;
 use Liberu\Billing\Collections\Enums\CollectionStatus;
 use Liberu\Billing\Collections\Models\CollectionCase;
 
@@ -31,6 +32,15 @@ it('rejects unsupported collection case types', function (): void {
     expect(fn () => app(OpenCollectionCase::class)->execute([
         'amount_minor' => 100, 'currency' => 'USD', 'type' => 'unsupported',
     ]))->toThrow(InvalidArgumentException::class, 'Collection case type is invalid.');
+});
+
+it('does not write off a case after its persisted state becomes recovered', function (): void {
+    $case = app(OpenCollectionCase::class)->execute(['team_id' => 10, 'amount_minor' => 100, 'currency' => 'USD']);
+    $case->refresh();
+    CollectionCase::query()->whereKey($case->getKey())->update(['status' => CollectionStatus::Recovered->value]);
+
+    expect(fn () => app(WriteOffCollectionCase::class)->execute($case, 'uncollectible'))
+        ->toThrow(LogicException::class, 'This collection case cannot be written off.');
 });
 
 it('records dunning, reminder, and credit-control decisions', function () {

--- a/tests/Unit/BillingCollectionsTest.php
+++ b/tests/Unit/BillingCollectionsTest.php
@@ -11,6 +11,7 @@ use Liberu\Billing\Collections\Actions\SuspendCollectionCase;
 use Liberu\Billing\Collections\Actions\WriteOffCollectionCase;
 use Liberu\Billing\Collections\Enums\CollectionStatus;
 use Liberu\Billing\Collections\Models\CollectionCase;
+use Liberu\Billing\Invoicing\Models\Invoice;
 
 uses(RefreshDatabase::class);
 
@@ -32,6 +33,17 @@ it('rejects unsupported collection case types', function (): void {
     expect(fn () => app(OpenCollectionCase::class)->execute([
         'amount_minor' => 100, 'currency' => 'USD', 'type' => 'unsupported',
     ]))->toThrow(InvalidArgumentException::class, 'Collection case type is invalid.');
+});
+
+it('rejects a collection case invoice owned by another team', function (): void {
+    $invoice = Invoice::query()->create([
+        'team_id' => 20, 'status' => 'draft', 'currency' => 'USD',
+        'subtotal_minor' => 100, 'tax_minor' => 0, 'total_minor' => 100,
+    ]);
+
+    expect(fn () => app(OpenCollectionCase::class)->execute([
+        'team_id' => 10, 'invoice_id' => $invoice->getKey(), 'amount_minor' => 100, 'currency' => 'USD',
+    ]))->toThrow(InvalidArgumentException::class, 'Collection invoice reference is invalid.');
 });
 
 it('does not write off a case after its persisted state becomes recovered', function (): void {

--- a/tests/Unit/BillingCommunicationsTest.php
+++ b/tests/Unit/BillingCommunicationsTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Communications\Actions\CreateCommunicationService;
 use Liberu\Billing\Communications\Actions\TransitionCommunicationNumber;
+use Liberu\Billing\Communications\Actions\TransitionCommunicationService;
 use Liberu\Billing\Communications\Models\CommunicationNumber;
+use Liberu\Billing\Communications\Models\CommunicationService;
 
 uses(RefreshDatabase::class);
 
@@ -19,4 +22,13 @@ it('rejects unknown communication number states', function () {
 
     expect(fn () => app(TransitionCommunicationNumber::class)->handle($number, 'unknown'))
         ->toThrow(InvalidArgumentException::class);
+});
+
+it('does not reactivate a communication service after its persisted state becomes cancelled', function (): void {
+    $service = app(CreateCommunicationService::class)->handle(10, ['name' => 'Transactional email']);
+    $service->refresh();
+    CommunicationService::query()->whereKey($service->getKey())->update(['status' => 'cancelled']);
+
+    expect(fn () => app(TransitionCommunicationService::class)->handle($service, 'active'))
+        ->toThrow(InvalidArgumentException::class, 'Cancelled communication services cannot be reactivated.');
 });

--- a/tests/Unit/BillingCommunicationsTest.php
+++ b/tests/Unit/BillingCommunicationsTest.php
@@ -32,3 +32,12 @@ it('does not reactivate a communication service after its persisted state become
     expect(fn () => app(TransitionCommunicationService::class)->handle($service, 'active'))
         ->toThrow(InvalidArgumentException::class, 'Cancelled communication services cannot be reactivated.');
 });
+
+it('does not reactivate a communication number after its persisted state becomes released', function (): void {
+    $number = CommunicationNumber::query()->create(['team_id' => 10, 'number' => '+12025550102', 'type' => 'phone', 'status' => 'available']);
+    $number->refresh();
+    CommunicationNumber::query()->whereKey($number->getKey())->update(['status' => 'released']);
+
+    expect(fn () => app(TransitionCommunicationNumber::class)->handle($number, 'active'))
+        ->toThrow(InvalidArgumentException::class, 'Released communication numbers cannot be reactivated.');
+});

--- a/tests/Unit/BillingCoreTest.php
+++ b/tests/Unit/BillingCoreTest.php
@@ -2,10 +2,13 @@
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Core\Actions\CreateBillingAccount;
+use Liberu\Billing\Core\Actions\CreateBillingRecord;
 use Liberu\Billing\Core\Actions\TransitionBillingAccount;
 use Liberu\Billing\Core\Actions\UpdateBillingAccount;
+use Liberu\Billing\Core\Actions\UpdateBillingRecord;
 use Liberu\Billing\Core\Enums\BillingAccountStatus;
 use Liberu\Billing\Core\Models\BillingAccount;
+use Liberu\Billing\Core\Models\BillingContact;
 
 uses(RefreshDatabase::class);
 
@@ -35,4 +38,16 @@ it('does not transition an account after its persisted state becomes closed', fu
 
     expect(fn () => app(TransitionBillingAccount::class)->execute($account, BillingAccountStatus::Active))
         ->toThrow(InvalidArgumentException::class, 'A closed billing account cannot be reopened.');
+});
+
+it('updates a locked billing core record from its persisted state', function (): void {
+    $contact = app(CreateBillingRecord::class)->execute(BillingContact::class, [
+        'team_id' => 10, 'name' => 'Original', 'email' => 'original@example.com',
+    ]);
+    $contact->refresh();
+
+    $updated = app(UpdateBillingRecord::class)->execute($contact, ['name' => 'Updated']);
+
+    expect($updated->name)->toBe('Updated')
+        ->and($updated->email)->toBe('original@example.com');
 });

--- a/tests/Unit/BillingCoreTest.php
+++ b/tests/Unit/BillingCoreTest.php
@@ -5,6 +5,7 @@ use Liberu\Billing\Core\Actions\CreateBillingAccount;
 use Liberu\Billing\Core\Actions\TransitionBillingAccount;
 use Liberu\Billing\Core\Actions\UpdateBillingAccount;
 use Liberu\Billing\Core\Enums\BillingAccountStatus;
+use Liberu\Billing\Core\Models\BillingAccount;
 
 uses(RefreshDatabase::class);
 
@@ -25,4 +26,13 @@ it('does not reopen a closed billing account', function () {
 
     expect(fn () => app(TransitionBillingAccount::class)->execute($closed, BillingAccountStatus::Active))
         ->toThrow(InvalidArgumentException::class);
+});
+
+it('does not transition an account after its persisted state becomes closed', function (): void {
+    $account = app(CreateBillingAccount::class)->execute(['team_id' => 10, 'name' => 'Stale', 'currency' => 'USD']);
+    $account->refresh();
+    BillingAccount::query()->whereKey($account->getKey())->update(['status' => BillingAccountStatus::Closed->value]);
+
+    expect(fn () => app(TransitionBillingAccount::class)->execute($account, BillingAccountStatus::Active))
+        ->toThrow(InvalidArgumentException::class, 'A closed billing account cannot be reopened.');
 });

--- a/tests/Unit/BillingCoreTest.php
+++ b/tests/Unit/BillingCoreTest.php
@@ -51,3 +51,16 @@ it('updates a locked billing core record from its persisted state', function ():
     expect($updated->name)->toBe('Updated')
         ->and($updated->email)->toBe('original@example.com');
 });
+
+it('updates a billing account from its locked persisted state', function (): void {
+    $account = app(CreateBillingAccount::class)->execute([
+        'team_id' => 10, 'name' => 'Original account', 'currency' => 'USD', 'settings' => ['timezone' => 'UTC'],
+    ]);
+    $account->refresh();
+    BillingAccount::query()->whereKey($account->getKey())->update(['settings' => json_encode(['timezone' => 'Europe/London'])]);
+
+    $updated = app(UpdateBillingAccount::class)->execute($account, ['name' => 'Updated account']);
+
+    expect($updated->name)->toBe('Updated account')
+        ->and($updated->settings)->toBe(['timezone' => 'Europe/London']);
+});

--- a/tests/Unit/BillingCustomerPortalTest.php
+++ b/tests/Unit/BillingCustomerPortalTest.php
@@ -22,3 +22,12 @@ it('rejects unsupported portal lifecycle states', function () {
     expect(fn () => app(TransitionPortalItem::class)->handle($item, 'unknown'))
         ->toThrow(InvalidArgumentException::class);
 });
+
+it('does not reopen a portal request after its persisted state becomes closed', function (): void {
+    $request = PortalRequest::query()->create(['team_id' => 10, 'name' => 'Stale request', 'status' => 'active']);
+    $request->refresh();
+    PortalRequest::query()->whereKey($request->getKey())->update(['status' => 'closed']);
+
+    expect(fn () => app(TransitionPortalRequest::class)->handle($request, 'active'))
+        ->toThrow(InvalidArgumentException::class, 'Closed portal requests cannot be reopened.');
+});

--- a/tests/Unit/BillingCustomerPortalTest.php
+++ b/tests/Unit/BillingCustomerPortalTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\CustomerPortal\Actions\CreatePortalItem;
 use Liberu\Billing\CustomerPortal\Actions\TransitionPortalItem;
 use Liberu\Billing\CustomerPortal\Actions\TransitionPortalRequest;
 use Liberu\Billing\CustomerPortal\Models\PortalItem;
@@ -39,4 +42,13 @@ it('does not reopen a portal item after its persisted state becomes completed', 
 
     expect(fn () => app(TransitionPortalItem::class)->handle($item, 'in_progress'))
         ->toThrow(InvalidArgumentException::class, 'Completed or cancelled portal items cannot be reopened.');
+});
+
+it('rejects a portal item customer owned by another team', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+
+    expect(fn () => app(CreatePortalItem::class)->handle(10, [
+        'customer_id' => $customerId, 'type' => 'invoices', 'subject' => 'View invoices',
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });

--- a/tests/Unit/BillingCustomerPortalTest.php
+++ b/tests/Unit/BillingCustomerPortalTest.php
@@ -31,3 +31,12 @@ it('does not reopen a portal request after its persisted state becomes closed', 
     expect(fn () => app(TransitionPortalRequest::class)->handle($request, 'active'))
         ->toThrow(InvalidArgumentException::class, 'Closed portal requests cannot be reopened.');
 });
+
+it('does not reopen a portal item after its persisted state becomes completed', function (): void {
+    $item = PortalItem::query()->create(['team_id' => 10, 'type' => 'services', 'status' => 'open', 'subject' => 'Provision service']);
+    $item->refresh();
+    PortalItem::query()->whereKey($item->getKey())->update(['status' => 'completed']);
+
+    expect(fn () => app(TransitionPortalItem::class)->handle($item, 'in_progress'))
+        ->toThrow(InvalidArgumentException::class, 'Completed or cancelled portal items cannot be reopened.');
+});

--- a/tests/Unit/BillingDomainsTest.php
+++ b/tests/Unit/BillingDomainsTest.php
@@ -47,7 +47,7 @@ it('only writes DNS records for domains owned by the current team', function () 
 });
 
 it('synchronizes registrar TLD costs with the configured markup', function () {
-    app(RegistrarManager::class)->register('test', new class() implements RegistrarClient
+    app(RegistrarManager::class)->register(' TEST ', new class() implements RegistrarClient
     {
         public function registerDomain(string $domainName, mixed $customerId): ?array
         {

--- a/tests/Unit/BillingDomainsTest.php
+++ b/tests/Unit/BillingDomainsTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Domains\Actions\CreateDomain;
+use Liberu\Billing\Domains\Actions\UpdateDomain;
 use Liberu\Billing\Domains\Actions\UpsertDnsRecord;
 use Liberu\Billing\Domains\Contracts\RegistrarClient;
 use Liberu\Billing\Domains\Models\DomainTld;
@@ -107,4 +108,15 @@ it('synchronizes registrar TLD costs with the configured markup', function () {
     expect(app(DomainPricingService::class)->syncTlds('test', 20))->toBe(2)
         ->and(DomainTld::query()->where('name', '.com')->value('markup_value'))->toBe('20.0000')
         ->and(DomainTld::query()->where('name', '.net')->value('registrar_cost'))->toBe('8.0000');
+});
+
+it('updates the persisted domain row instead of a stale model instance', function (): void {
+    $domain = app(CreateDomain::class)->handle(10, ['name' => 'example.com']);
+    $domain->refresh();
+    app(UpdateDomain::class)->handle($domain, ['status' => 'registered']);
+
+    $updated = app(UpdateDomain::class)->handle($domain, ['name' => 'new-example.com']);
+
+    expect($updated->name)->toBe('new-example.com')
+        ->and($updated->status)->toBe('registered');
 });

--- a/tests/Unit/BillingDomainsTest.php
+++ b/tests/Unit/BillingDomainsTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Domains\Actions\CreateDomain;
+use Liberu\Billing\Domains\Actions\RegisterDomain;
+use Liberu\Billing\Domains\Actions\TransferDomain;
 use Liberu\Billing\Domains\Actions\UpdateDomain;
 use Liberu\Billing\Domains\Actions\UpsertDnsRecord;
 use Liberu\Billing\Domains\Contracts\RegistrarClient;
@@ -119,4 +123,15 @@ it('updates the persisted domain row instead of a stale model instance', functio
 
     expect($updated->name)->toBe('new-example.com')
         ->and($updated->status)->toBe('registered');
+});
+
+it('rejects registrar operations for a customer owned by another team', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+    $domain = app(CreateDomain::class)->handle(10, ['name' => 'example.com']);
+
+    expect(fn () => app(RegisterDomain::class)->execute($domain, $customerId))
+        ->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.')
+        ->and(fn () => app(TransferDomain::class)->execute($domain, 'AUTH-CODE', $customerId))
+        ->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });

--- a/tests/Unit/BillingDomainsTest.php
+++ b/tests/Unit/BillingDomainsTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Domains\Actions\CreateDomain;
+use Liberu\Billing\Domains\Actions\UpsertDnsRecord;
 use Liberu\Billing\Domains\Contracts\RegistrarClient;
 use Liberu\Billing\Domains\Models\DomainTld;
 use Liberu\Billing\Domains\Services\DomainPricingService;
@@ -21,6 +23,26 @@ it('prices supported TLDs with configured markup and preserves hosting bundles',
 it('rejects unsupported domain suffixes', function () {
     expect(fn () => app(DomainPricingService::class)->calculateDomainPrice('example.invalid'))
         ->toThrow(InvalidArgumentException::class);
+});
+
+it('only writes DNS records for domains owned by the current team', function () {
+    $domain = app(CreateDomain::class)->handle(20, ['name' => 'example.com']);
+
+    expect(fn () => app(UpsertDnsRecord::class)->execute(10, [
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'host' => '@',
+        'value' => '192.0.2.10',
+    ]))->toThrow(InvalidArgumentException::class);
+
+    $record = app(UpsertDnsRecord::class)->execute(20, [
+        'domain_id' => $domain->id,
+        'type' => 'A',
+        'host' => ' @ ',
+        'value' => ' 192.0.2.10 ',
+    ]);
+
+    expect($record->host)->toBe('@')->and($record->value)->toBe('192.0.2.10');
 });
 
 it('synchronizes registrar TLD costs with the configured markup', function () {

--- a/tests/Unit/BillingInvoicingTest.php
+++ b/tests/Unit/BillingInvoicingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Invoicing\Actions\AddInvoiceLine;
@@ -51,6 +53,18 @@ it('rejects empty finalization and invalid currency', function () {
     $invoice = app(CreateInvoice::class)->execute(['currency' => 'USD']);
     expect(fn () => app(FinalizeInvoice::class)->execute($invoice))
         ->toThrow(LogicException::class);
+});
+
+it('rejects foreign customer references for invoices and schedules', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+
+    expect(fn () => app(CreateInvoice::class)->execute([
+        'team_id' => 10, 'customer_id' => $customerId, 'currency' => 'USD',
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.')
+        ->and(fn () => app(CreateInvoiceSchedule::class)->execute([
+            'team_id' => 10, 'customer_id' => $customerId, 'frequency' => 'monthly',
+        ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });
 
 it('does not deliver a draft invoice after its persisted state changes', function (): void {

--- a/tests/Unit/BillingInvoicingTest.php
+++ b/tests/Unit/BillingInvoicingTest.php
@@ -53,6 +53,13 @@ it('rejects empty finalization and invalid currency', function () {
         ->toThrow(LogicException::class);
 });
 
+it('does not deliver a draft invoice after its persisted state changes', function (): void {
+    $invoice = app(CreateInvoice::class)->execute(['team_id' => 10, 'currency' => 'USD']);
+
+    expect(fn () => app(DeliverInvoice::class)->execute($invoice, 'billing@example.com'))
+        ->toThrow(LogicException::class, 'Only finalized invoices can be delivered.');
+});
+
 it('allows read tokens to view but not update their team invoice', function () {
     $invoice = app(CreateInvoice::class)->execute(['team_id' => 10, 'currency' => 'USD']);
     $readUser = new class() implements Authenticatable

--- a/tests/Unit/BillingInvoicingTest.php
+++ b/tests/Unit/BillingInvoicingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Invoicing\Actions\AddInvoiceLine;
 use Liberu\Billing\Invoicing\Actions\ApplyInvoiceAdjustment;
+use Liberu\Billing\Invoicing\Actions\ApplyInvoiceLateFee;
 use Liberu\Billing\Invoicing\Actions\CreateInvoice;
 use Liberu\Billing\Invoicing\Actions\CreateInvoiceSchedule;
 use Liberu\Billing\Invoicing\Actions\CreateInvoiceSupport;
@@ -185,4 +186,20 @@ it('applies credits and generates and delivers an invoice document', function ()
         ->and(base64_decode($document->payload['content_base64'], true))->toStartWith('%PDF')
         ->and($delivery->status)->toBe('delivered')
         ->and($delivery->destination)->toBe('billing@example.com');
+});
+
+it('applies one idempotent late fee per overdue invoice day', function (): void {
+    $dueAt = now()->subDay();
+    $invoice = app(CreateInvoice::class)->execute(['team_id' => 10, 'currency' => 'USD', 'due_at' => $dueAt]);
+    app(AddInvoiceLine::class)->execute($invoice, 'Service', 1, 1000, 0);
+    $invoice = app(FinalizeInvoice::class)->execute($invoice->refresh());
+
+    $at = $dueAt->copy()->addDay();
+    $updated = app(ApplyInvoiceLateFee::class)->execute($invoice, 125, $at);
+    $sameDay = app(ApplyInvoiceLateFee::class)->execute($updated, 250, $at);
+
+    expect($sameDay->total_minor)->toBe(1125)
+        ->and($sameDay->metadata['late_fees'])->toHaveCount(1)
+        ->and($sameDay->metadata['late_fees'][0]['amount_minor'])->toBe(125)
+        ->and($sameDay->supports()->count())->toBe(1);
 });

--- a/tests/Unit/BillingInvoicingTest.php
+++ b/tests/Unit/BillingInvoicingTest.php
@@ -125,6 +125,24 @@ it('runs a due recurring schedule and advances its next run', function () {
         ->and($schedule->refresh()->next_run_at->isFuture())->toBeTrue();
 });
 
+it('claims a recurring schedule before allowing another invoice run', function () {
+    $schedule = app(CreateInvoiceSchedule::class)->execute([
+        'team_id' => 10,
+        'frequency' => 'monthly',
+        'next_run_at' => now()->subMinute(),
+        'metadata' => [
+            'currency' => 'USD',
+            'lines' => [['description' => 'Service', 'quantity' => 1, 'unit_amount_minor' => 1000]],
+        ],
+    ]);
+
+    app(RunInvoiceSchedule::class)->execute($schedule);
+
+    expect(fn () => app(RunInvoiceSchedule::class)->execute($schedule->refresh()))
+        ->toThrow(LogicException::class, 'Invoice schedule is not due yet.')
+        ->and($schedule->refresh()->next_run_at->isFuture())->toBeTrue();
+});
+
 it('rejects invalid invoice schedule frequencies', function () {
     expect(fn () => app(CreateInvoiceSchedule::class)->execute(['frequency' => 'hourly']))
         ->toThrow(InvalidArgumentException::class);

--- a/tests/Unit/BillingIspTest.php
+++ b/tests/Unit/BillingIspTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Isp\Actions\CreateAccessService;
+use Liberu\Billing\Isp\Actions\CreateIspCapability;
+use Liberu\Billing\Isp\Actions\TransitionAccessService;
+use Liberu\Billing\Isp\Actions\TransitionIspCapability;
+
+uses(RefreshDatabase::class);
+
+it('does not reactivate cancelled ISP access services or capabilities', function (): void {
+    $service = app(CreateAccessService::class)->handle(10, ['name' => 'Broadband']);
+    $service = app(TransitionAccessService::class)->handle($service, 'cancelled');
+    $capability = app(CreateIspCapability::class)->handle(10, ['type' => 'radius', 'name' => 'RADIUS']);
+    $capability = app(TransitionIspCapability::class)->handle($capability, 'cancelled');
+
+    expect(fn () => app(TransitionAccessService::class)->handle($service, 'active'))
+        ->toThrow(LogicException::class)
+        ->and(fn () => app(TransitionIspCapability::class)->handle($capability, 'active'))
+        ->toThrow(LogicException::class);
+});

--- a/tests/Unit/BillingOrdersTest.php
+++ b/tests/Unit/BillingOrdersTest.php
@@ -2,9 +2,11 @@
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Orders\Actions\CreateOrder;
+use Liberu\Billing\Orders\Actions\ReviewFraud;
 use Liberu\Billing\Orders\Actions\TransitionOrder;
 use Liberu\Billing\Orders\Enums\FraudReviewStatus;
 use Liberu\Billing\Orders\Enums\OrderStatus;
+use Liberu\Billing\Orders\Models\Order;
 
 uses(RefreshDatabase::class);
 
@@ -67,4 +69,15 @@ it('does not transition an order after its persisted state becomes terminal', fu
 
     expect(fn () => app(TransitionOrder::class)->execute($order, OrderStatus::Cancelled))
         ->toThrow(LogicException::class, 'Terminal orders cannot transition.');
+});
+
+it('does not review fraud after an order becomes terminal', function (): void {
+    $order = app(CreateOrder::class)->execute([
+        'order_number' => 'ORD-1004', 'currency' => 'USD', 'subtotal_minor' => 100,
+    ]);
+    $order->refresh();
+    Order::query()->whereKey($order->getKey())->update(['status' => OrderStatus::Completed->value]);
+
+    expect(fn () => app(ReviewFraud::class)->execute($order, FraudReviewStatus::Blocked))
+        ->toThrow(LogicException::class, 'Terminal orders cannot receive fraud reviews.');
 });

--- a/tests/Unit/BillingOrdersTest.php
+++ b/tests/Unit/BillingOrdersTest.php
@@ -53,5 +53,18 @@ it('rejects invalid order amounts', function () {
         'currency' => 'USD',
         'subtotal_minor' => 100,
         'discount_minor' => 101,
-    ]))->toThrow(InvalidArgumentException::class);
+        ]))->toThrow(InvalidArgumentException::class);
+});
+
+it('does not transition an order after its persisted state becomes terminal', function (): void {
+    $order = app(CreateOrder::class)->execute([
+        'order_number' => 'ORD-1003',
+        'currency' => 'USD',
+        'subtotal_minor' => 100,
+    ]);
+    $order->refresh();
+    $order->update(['status' => OrderStatus::Completed]);
+
+    expect(fn () => app(TransitionOrder::class)->execute($order, OrderStatus::Cancelled))
+        ->toThrow(LogicException::class, 'Terminal orders cannot transition.');
 });

--- a/tests/Unit/BillingOrdersTest.php
+++ b/tests/Unit/BillingOrdersTest.php
@@ -10,6 +10,7 @@ use Liberu\Billing\Orders\Enums\FraudReviewStatus;
 use Liberu\Billing\Orders\Enums\OrderStatus;
 use Liberu\Billing\Orders\Models\Cart;
 use Liberu\Billing\Orders\Models\Order;
+use Liberu\Billing\Orders\Models\Quote;
 
 uses(RefreshDatabase::class);
 
@@ -59,6 +60,17 @@ it('rejects invalid order amounts', function () {
         'subtotal_minor' => 100,
         'discount_minor' => 101,
         ]))->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects a quote owned by another team', function (): void {
+    $quote = Quote::query()->create([
+        'team_id' => 20, 'quote_number' => 'QUO-FOREIGN', 'currency' => 'USD',
+        'total_minor' => 100, 'items' => [], 'status' => 'draft',
+    ]);
+
+    expect(fn () => app(CreateOrder::class)->execute([
+        'team_id' => 10, 'quote_id' => $quote->getKey(), 'currency' => 'USD', 'subtotal_minor' => 100,
+    ]))->toThrow(InvalidArgumentException::class, 'Order quote reference is invalid.');
 });
 
 it('does not transition an order after its persisted state becomes terminal', function (): void {

--- a/tests/Unit/BillingOrdersTest.php
+++ b/tests/Unit/BillingOrdersTest.php
@@ -1,9 +1,13 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Orders\Actions\AddChangeOrder;
 use Liberu\Billing\Orders\Actions\CheckoutCart;
+use Liberu\Billing\Orders\Actions\CreateCart;
 use Liberu\Billing\Orders\Actions\CreateOrder;
+use Liberu\Billing\Orders\Actions\CreateQuote;
 use Liberu\Billing\Orders\Actions\ReviewFraud;
 use Liberu\Billing\Orders\Actions\TransitionOrder;
 use Liberu\Billing\Orders\Enums\FraudReviewStatus;
@@ -71,6 +75,21 @@ it('rejects a quote owned by another team', function (): void {
     expect(fn () => app(CreateOrder::class)->execute([
         'team_id' => 10, 'quote_id' => $quote->getKey(), 'currency' => 'USD', 'subtotal_minor' => 100,
     ]))->toThrow(InvalidArgumentException::class, 'Order quote reference is invalid.');
+});
+
+it('rejects foreign customer references for orders, quotes, and carts', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+
+    expect(fn () => app(CreateOrder::class)->execute([
+        'team_id' => 10, 'customer_id' => $customerId, 'currency' => 'USD', 'subtotal_minor' => 100,
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.')
+        ->and(fn () => app(CreateQuote::class)->execute([
+            'team_id' => 10, 'customer_id' => $customerId, 'currency' => 'USD', 'total_minor' => 100, 'items' => [['name' => 'Item']],
+        ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.')
+        ->and(fn () => app(CreateCart::class)->execute([
+            'team_id' => 10, 'customer_id' => $customerId, 'currency' => 'USD', 'items' => [['name' => 'Item']],
+        ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });
 
 it('does not transition an order after its persisted state becomes terminal', function (): void {

--- a/tests/Unit/BillingOrdersTest.php
+++ b/tests/Unit/BillingOrdersTest.php
@@ -1,11 +1,14 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Orders\Actions\AddChangeOrder;
+use Liberu\Billing\Orders\Actions\CheckoutCart;
 use Liberu\Billing\Orders\Actions\CreateOrder;
 use Liberu\Billing\Orders\Actions\ReviewFraud;
 use Liberu\Billing\Orders\Actions\TransitionOrder;
 use Liberu\Billing\Orders\Enums\FraudReviewStatus;
 use Liberu\Billing\Orders\Enums\OrderStatus;
+use Liberu\Billing\Orders\Models\Cart;
 use Liberu\Billing\Orders\Models\Order;
 
 uses(RefreshDatabase::class);
@@ -80,4 +83,25 @@ it('does not review fraud after an order becomes terminal', function (): void {
 
     expect(fn () => app(ReviewFraud::class)->execute($order, FraudReviewStatus::Blocked))
         ->toThrow(LogicException::class, 'Terminal orders cannot receive fraud reviews.');
+});
+
+it('appends change orders from the persisted order state', function (): void {
+    $order = app(CreateOrder::class)->execute([
+        'order_number' => 'ORD-1005', 'currency' => 'USD', 'subtotal_minor' => 100,
+    ]);
+    $order->refresh();
+    Order::query()->whereKey($order->getKey())->update(['change_orders' => [['reason' => 'existing']]]);
+
+    $updated = app(AddChangeOrder::class)->execute($order, ['reason' => 'new change']);
+
+    expect($updated->change_orders)->toHaveCount(2);
+});
+
+it('does not check out a cart after its persisted state becomes checked out', function (): void {
+    $cart = Cart::query()->create(['currency' => 'USD', 'items' => [], 'status' => 'open']);
+    $cart->refresh();
+    Cart::query()->whereKey($cart->getKey())->update(['status' => 'checked_out']);
+
+    expect(fn () => app(CheckoutCart::class)->execute($cart, ['subtotal_minor' => 100]))
+        ->toThrow(LogicException::class, 'Only open, non-expired carts can be checked out.');
 });

--- a/tests/Unit/BillingPaddleTest.php
+++ b/tests/Unit/BillingPaddleTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Liberu\Billing\Paddle\PaddleGatewayDriver;
+use Liberu\Billing\Payments\Models\Payment;
+
+it('captures a Paddle transaction through the provider-neutral gateway contract', function (): void {
+    config()->set('services.paddle.token', 'pdl_test_token');
+    config()->set('services.paddle.base_url', 'https://paddle.test');
+    Http::fake(['https://paddle.test/transactions' => Http::response([
+        'data' => ['id' => 'txn_123', 'status' => 'completed'],
+    ])]);
+
+    $payment = new Payment(['metadata' => [
+        'paddle_price_id' => 'pri_123abc',
+        'paddle_quantity' => 2,
+        'paddle_customer_id' => 'ctm_123',
+    ]]);
+    $payment->id = 42;
+
+    expect(app(PaddleGatewayDriver::class)->capture($payment))->toBe(['reference' => 'txn_123']);
+
+    Http::assertSent(function (Request $request): bool {
+        return $request->hasHeader('Authorization', 'Bearer pdl_test_token')
+            && $request->url() === 'https://paddle.test/transactions'
+            && $request['items'] === [['price_id' => 'pri_123abc', 'quantity' => 2]]
+            && $request['custom_data'] === ['billing_payment_id' => '42'];
+    });
+});
+
+it('supports full and partial Paddle refunds', function (): void {
+    config()->set('services.paddle.token', 'pdl_test_token');
+    Http::fake(['https://api.paddle.com/adjustments' => Http::sequence()
+        ->push(['data' => ['id' => 'adj_full']])
+        ->push(['data' => ['id' => 'adj_partial']])]);
+
+    $driver = app(PaddleGatewayDriver::class);
+    $payment = new Payment([
+        'amount_minor' => 1000,
+        'provider_reference' => 'txn_123',
+        'metadata' => ['paddle_transaction_item_id' => 'item_123'],
+    ]);
+
+    expect($driver->refund($payment, 1000))->toBe(['reference' => 'adj_full'])
+        ->and($driver->refund($payment, 400))->toBe(['reference' => 'adj_partial']);
+
+    Http::assertSentCount(2);
+    Http::assertSent(function (Request $request): bool {
+        return $request['type'] === 'partial'
+            && $request['items'] === [['item_id' => 'item_123', 'type' => 'partial', 'amount' => '400']];
+    });
+});
+
+it('rejects invalid Paddle metadata and incomplete provider responses', function (): void {
+    Http::fake(['https://api.paddle.com/transactions' => Http::response([
+        'data' => ['status' => 'completed'],
+    ])]);
+    $driver = app(PaddleGatewayDriver::class);
+    $payment = new Payment(['metadata' => ['paddle_price_id' => 'invalid']]);
+
+    expect(fn () => $driver->capture($payment))->toThrow(InvalidArgumentException::class)
+        ->and(fn () => $driver->capture(new Payment(['metadata' => ['paddle_price_id' => 'pri_valid']])))->toThrow(RuntimeException::class);
+});
+
+it('does not treat a checkout-ready Paddle transaction as captured', function (): void {
+    Http::fake(['https://api.paddle.com/transactions' => Http::response([
+        'data' => ['id' => 'txn_ready', 'status' => 'ready'],
+    ])]);
+
+    expect(fn () => app(PaddleGatewayDriver::class)->capture(new Payment([
+        'metadata' => ['paddle_price_id' => 'pri_valid'],
+    ])))->toThrow(RuntimeException::class, 'Paddle transaction is not complete: ready');
+});

--- a/tests/Unit/BillingPaddleTest.php
+++ b/tests/Unit/BillingPaddleTest.php
@@ -3,7 +3,9 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Liberu\Billing\Paddle\PaddleGatewayDriver;
+use Liberu\Billing\Payments\Contracts\GatewayDriver;
 use Liberu\Billing\Payments\Models\Payment;
+use Liberu\Billing\Payments\Services\GatewayManager;
 
 it('captures a Paddle transaction through the provider-neutral gateway contract', function (): void {
     config()->set('services.paddle.token', 'pdl_test_token');
@@ -71,4 +73,23 @@ it('does not treat a checkout-ready Paddle transaction as captured', function ()
     expect(fn () => app(PaddleGatewayDriver::class)->capture(new Payment([
         'metadata' => ['paddle_price_id' => 'pri_valid'],
     ])))->toThrow(RuntimeException::class, 'Paddle transaction is not complete: ready');
+});
+
+it('resolves the Paddle gateway without case-sensitive aliases', function (): void {
+    $manager = new GatewayManager();
+    $driver = new class() implements GatewayDriver
+    {
+        public function capture(Payment $payment): array
+        {
+            return [];
+        }
+
+        public function refund(Payment $payment, int $amountMinor): array
+        {
+            return [];
+        }
+    };
+    $manager->register(' Paddle ', $driver);
+
+    expect($manager->driver('PADDLE'))->toBe($driver);
 });

--- a/tests/Unit/BillingPaymentsTest.php
+++ b/tests/Unit/BillingPaymentsTest.php
@@ -67,3 +67,13 @@ it('requires a gateway before refunding a captured payment', function () {
     expect(fn () => app(RefundPayment::class)->execute($payment->refresh(), 1))
         ->toThrow(InvalidArgumentException::class);
 });
+
+it('does not open a dispute after the persisted payment state changes', function (): void {
+    $payment = app(CreatePayment::class)->execute(['amount_minor' => 100, 'currency' => 'EUR']);
+    $payment->update(['status' => PaymentStatus::Captured]);
+    $payment->refresh();
+    Payment::query()->whereKey($payment->getKey())->update(['status' => PaymentStatus::Disputed]);
+
+    expect(fn () => app(OpenDispute::class)->execute($payment, 1, 'customer claim'))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Unit/BillingPaymentsTest.php
+++ b/tests/Unit/BillingPaymentsTest.php
@@ -36,12 +36,14 @@ it('captures, allocates, refunds, disputes, and reconciles a payment', function 
     $refund = app(RefundPayment::class)->execute($payment, 400);
     $dispute = app(OpenDispute::class)->execute($payment->refresh(), 100, 'customer claim');
     $reconciliation = app(ReconcilePayment::class)->execute($payment, 'capture-1');
+    $duplicateReconciliation = app(ReconcilePayment::class)->execute($payment, ' capture-1 ');
 
     expect($payment->refresh()->status)->toBe(PaymentStatus::Disputed)
         ->and($allocation->amount_minor)->toBe(600)
         ->and($refund->amount_minor)->toBe(400)
         ->and($dispute->status)->toBe(DisputeStatus::Open)
-        ->and($reconciliation->status)->toBe(ReconciliationStatus::Matched);
+        ->and($reconciliation->status)->toBe(ReconciliationStatus::Matched)
+        ->and($duplicateReconciliation->is($reconciliation))->toBeTrue();
 });
 
 it('rejects over-allocation and refunds on a pending payment', function () {

--- a/tests/Unit/BillingPaymentsTest.php
+++ b/tests/Unit/BillingPaymentsTest.php
@@ -102,6 +102,18 @@ it('rejects an allocation invoice owned by another team', function (): void {
         ->toThrow(InvalidArgumentException::class, 'Payment invoice reference is invalid.');
 });
 
+it('rejects an allocation invoice for another customer', function (): void {
+    Team::factory()->create(['id' => 10]);
+    $paymentCustomer = Customer::factory()->create(['team_id' => 10]);
+    $invoiceCustomer = Customer::factory()->create(['team_id' => 10]);
+    $invoice = app(CreateInvoice::class)->execute(['team_id' => 10, 'customer_id' => $invoiceCustomer->getKey(), 'currency' => 'USD']);
+    $payment = app(CreatePayment::class)->execute(['team_id' => 10, 'customer_id' => $paymentCustomer->getKey(), 'amount_minor' => 100, 'currency' => 'USD']);
+    $payment->update(['status' => PaymentStatus::Captured]);
+
+    expect(fn () => app(AllocatePayment::class)->execute($payment->refresh(), 100, $invoice->getKey()))
+        ->toThrow(InvalidArgumentException::class, 'Payment invoice reference is invalid.');
+});
+
 it('does not open a dispute after the persisted payment state changes', function (): void {
     $payment = app(CreatePayment::class)->execute(['amount_minor' => 100, 'currency' => 'EUR']);
     $payment->update(['status' => PaymentStatus::Captured]);

--- a/tests/Unit/BillingPaymentsTest.php
+++ b/tests/Unit/BillingPaymentsTest.php
@@ -3,6 +3,7 @@
 use App\Models\Customer;
 use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Invoicing\Actions\CreateInvoice;
 use Liberu\Billing\Payments\Actions\AllocatePayment;
 use Liberu\Billing\Payments\Actions\CapturePayment;
 use Liberu\Billing\Payments\Actions\CreatePayment;
@@ -35,7 +36,8 @@ it('captures, allocates, refunds, disputes, and reconciles a payment', function 
 
     $payment = app(CreatePayment::class)->execute(['team_id' => 10, 'amount_minor' => 1000, 'currency' => 'usd', 'gateway' => 'test']);
     $payment = app(CapturePayment::class)->execute($payment);
-    $allocation = app(AllocatePayment::class)->execute($payment, 600, 15);
+    $invoice = app(CreateInvoice::class)->execute(['team_id' => 10, 'currency' => 'USD']);
+    $allocation = app(AllocatePayment::class)->execute($payment, 600, $invoice->getKey());
     $refund = app(RefundPayment::class)->execute($payment, 400);
     $dispute = app(OpenDispute::class)->execute($payment->refresh(), 100, 'customer claim');
     $reconciliation = app(ReconcilePayment::class)->execute($payment, 'capture-1');
@@ -89,6 +91,15 @@ it('rejects a payment customer owned by another team', function (): void {
     expect(fn () => app(CreatePayment::class)->execute([
         'team_id' => 10, 'customer_id' => $customerId, 'amount_minor' => 100, 'currency' => 'USD',
     ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
+});
+
+it('rejects an allocation invoice owned by another team', function (): void {
+    $invoice = app(CreateInvoice::class)->execute(['team_id' => 20, 'currency' => 'USD']);
+    $payment = app(CreatePayment::class)->execute(['team_id' => 10, 'amount_minor' => 100, 'currency' => 'USD']);
+    $payment->update(['status' => PaymentStatus::Captured]);
+
+    expect(fn () => app(AllocatePayment::class)->execute($payment->refresh(), 100, $invoice->getKey()))
+        ->toThrow(InvalidArgumentException::class, 'Payment invoice reference is invalid.');
 });
 
 it('does not open a dispute after the persisted payment state changes', function (): void {

--- a/tests/Unit/BillingPaymentsTest.php
+++ b/tests/Unit/BillingPaymentsTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Payments\Actions\AllocatePayment;
 use Liberu\Billing\Payments\Actions\CapturePayment;
 use Liberu\Billing\Payments\Actions\CreatePayment;
+use Liberu\Billing\Payments\Actions\CreatePaymentMethod;
 use Liberu\Billing\Payments\Actions\OpenDispute;
 use Liberu\Billing\Payments\Actions\ReconcilePayment;
 use Liberu\Billing\Payments\Actions\RefundPayment;
@@ -68,6 +71,15 @@ it('requires a gateway before refunding a captured payment', function () {
 
     expect(fn () => app(RefundPayment::class)->execute($payment->refresh(), 1))
         ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects a payment method customer owned by another team', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+
+    expect(fn () => app(CreatePaymentMethod::class)->execute([
+        'team_id' => 10, 'customer_id' => $customerId, 'type' => 'card', 'provider' => 'stripe',
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });
 
 it('does not open a dispute after the persisted payment state changes', function (): void {

--- a/tests/Unit/BillingPaymentsTest.php
+++ b/tests/Unit/BillingPaymentsTest.php
@@ -82,6 +82,15 @@ it('rejects a payment method customer owned by another team', function (): void 
     ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });
 
+it('rejects a payment customer owned by another team', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+
+    expect(fn () => app(CreatePayment::class)->execute([
+        'team_id' => 10, 'customer_id' => $customerId, 'amount_minor' => 100, 'currency' => 'USD',
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
+});
+
 it('does not open a dispute after the persisted payment state changes', function (): void {
     $payment = app(CreatePayment::class)->execute(['amount_minor' => 100, 'currency' => 'EUR']);
     $payment->update(['status' => PaymentStatus::Captured]);

--- a/tests/Unit/BillingPricingTest.php
+++ b/tests/Unit/BillingPricingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Catalog\Models\Product;
 use Liberu\Billing\Pricing\Actions\CalculatePricingPlanAmount;
 use Liberu\Billing\Pricing\Actions\CapturePricingSnapshot;
 use Liberu\Billing\Pricing\Actions\CreatePricingPlan;
@@ -44,6 +45,18 @@ it('rejects negative amounts and empty tier definitions', function () {
         ->toThrow(InvalidArgumentException::class);
     expect(fn () => $action->execute(['name' => 'Invalid', 'pricing_model' => 'tiered', 'currency' => 'USD', 'unit_amount_minor' => 0, 'tiers' => []]))
         ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects a product owned by another team', function (): void {
+    $product = Product::query()->create([
+        'team_id' => 20, 'name' => 'Foreign product', 'sku' => 'FOREIGN-PRODUCT',
+        'base_price_minor' => 100, 'currency' => 'USD', 'status' => 'draft',
+    ]);
+
+    expect(fn () => app(CreatePricingPlan::class)->execute([
+        'team_id' => 10, 'product_id' => $product->getKey(), 'name' => 'Plan',
+        'pricing_model' => 'one_time', 'currency' => 'USD', 'unit_amount_minor' => 100,
+    ]))->toThrow(InvalidArgumentException::class, 'Pricing product reference is invalid.');
 });
 
 it('calculates fixed, usage, and graduated tiered plan amounts in minor units', function () {

--- a/tests/Unit/BillingPricingTest.php
+++ b/tests/Unit/BillingPricingTest.php
@@ -59,6 +59,13 @@ it('rejects a product owned by another team', function (): void {
     ]))->toThrow(InvalidArgumentException::class, 'Pricing product reference is invalid.');
 });
 
+it('rejects a missing product reference', function (): void {
+    expect(fn () => app(CreatePricingPlan::class)->execute([
+        'team_id' => 10, 'product_id' => 999999, 'name' => 'Plan',
+        'pricing_model' => 'one_time', 'currency' => 'USD', 'unit_amount_minor' => 100,
+    ]))->toThrow(InvalidArgumentException::class, 'Pricing product reference is invalid.');
+});
+
 it('calculates fixed, usage, and graduated tiered plan amounts in minor units', function () {
     $create = app(CreatePricingPlan::class);
     $fixed = $create->execute(['name' => 'Fixed', 'pricing_model' => 'one_time', 'currency' => 'USD', 'unit_amount_minor' => 1250]);

--- a/tests/Unit/BillingPricingTest.php
+++ b/tests/Unit/BillingPricingTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Catalog\Models\Product;
 use Liberu\Billing\Pricing\Actions\CalculatePricingPlanAmount;
 use Liberu\Billing\Pricing\Actions\CapturePricingSnapshot;
+use Liberu\Billing\Pricing\Actions\CreatePricingContract;
 use Liberu\Billing\Pricing\Actions\CreatePricingPlan;
 use Liberu\Billing\Pricing\Enums\PricingModel;
 use Liberu\Billing\Pricing\Enums\PricingPlanStatus;
@@ -64,6 +67,25 @@ it('rejects a missing product reference', function (): void {
         'team_id' => 10, 'product_id' => 999999, 'name' => 'Plan',
         'pricing_model' => 'one_time', 'currency' => 'USD', 'unit_amount_minor' => 100,
     ]))->toThrow(InvalidArgumentException::class, 'Pricing product reference is invalid.');
+});
+
+it('validates pricing contract plan and customer ownership', function (): void {
+    $team = Team::factory()->create();
+    $customer = Customer::factory()->create(['team_id' => $team->getKey()]);
+    $plan = app(CreatePricingPlan::class)->execute([
+        'team_id' => $team->getKey(), 'name' => 'Contract plan', 'pricing_model' => 'one_time', 'currency' => 'USD', 'unit_amount_minor' => 100,
+    ]);
+
+    $contract = app(CreatePricingContract::class)->execute([
+        'team_id' => $team->getKey(), 'pricing_plan_id' => $plan->getKey(), 'customer_id' => $customer->getKey(),
+    ]);
+
+    expect($contract->customer_id)->toBe($customer->getKey())
+        ->and($contract->pricing_plan_id)->toBe($plan->getKey());
+
+    expect(fn () => app(CreatePricingContract::class)->execute([
+        'team_id' => $team->getKey() + 1, 'pricing_plan_id' => $plan->getKey(), 'customer_id' => $customer->getKey(),
+    ]))->toThrow(InvalidArgumentException::class, 'Pricing customer reference is invalid.');
 });
 
 it('calculates fixed, usage, and graduated tiered plan amounts in minor units', function () {

--- a/tests/Unit/BillingPricingTest.php
+++ b/tests/Unit/BillingPricingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\Billing\Pricing\Actions\CalculatePricingPlanAmount;
 use Liberu\Billing\Pricing\Actions\CapturePricingSnapshot;
 use Liberu\Billing\Pricing\Actions\CreatePricingPlan;
 use Liberu\Billing\Pricing\Enums\PricingModel;
@@ -42,6 +43,41 @@ it('rejects negative amounts and empty tier definitions', function () {
     expect(fn () => $action->execute(['name' => 'Invalid', 'pricing_model' => 'recurring', 'currency' => 'USD', 'unit_amount_minor' => -1]))
         ->toThrow(InvalidArgumentException::class);
     expect(fn () => $action->execute(['name' => 'Invalid', 'pricing_model' => 'tiered', 'currency' => 'USD', 'unit_amount_minor' => 0, 'tiers' => []]))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('calculates fixed, usage, and graduated tiered plan amounts in minor units', function () {
+    $create = app(CreatePricingPlan::class);
+    $fixed = $create->execute(['name' => 'Fixed', 'pricing_model' => 'one_time', 'currency' => 'USD', 'unit_amount_minor' => 1250]);
+    $usage = $create->execute(['name' => 'Usage', 'pricing_model' => 'usage', 'currency' => 'USD', 'unit_amount_minor' => 7, 'usage_unit' => 'seat']);
+    $tiered = $create->execute(['name' => 'Tiered', 'pricing_model' => 'tiered', 'currency' => 'USD', 'unit_amount_minor' => 0, 'tiers' => [
+        ['up_to' => 10, 'unit_amount_minor' => 100],
+        ['up_to' => 20, 'unit_amount_minor' => 75],
+        ['unit_amount_minor' => 50],
+    ]]);
+
+    $calculate = app(CalculatePricingPlanAmount::class);
+    expect($calculate->execute($fixed, ['quantity' => 99]))->toBe(1250)
+        ->and($calculate->execute($usage, ['quantity' => 3]))->toBe(21)
+        ->and($calculate->execute($tiered, ['quantity' => 25]))->toBe(2000);
+});
+
+it('rejects malformed pricing quantities and tiers', function () {
+    $plan = app(CreatePricingPlan::class)->execute(['name' => 'Tiered', 'pricing_model' => 'tiered', 'currency' => 'USD', 'unit_amount_minor' => 0, 'tiers' => [
+        ['up_to' => 10, 'unit_amount_minor' => 100],
+    ]]);
+    $calculate = app(CalculatePricingPlanAmount::class);
+
+    expect(fn () => $calculate->execute($plan, ['quantity' => -1]))
+        ->toThrow(InvalidArgumentException::class);
+
+    expect($calculate->execute($plan, ['quantity' => 20]))->toBe(2000);
+
+    $plan->tiers = [
+        ['up_to' => 10, 'unit_amount_minor' => 100],
+        ['up_to' => 5, 'unit_amount_minor' => 50],
+    ];
+    expect(fn () => $calculate->execute($plan, ['quantity' => 1]))
         ->toThrow(InvalidArgumentException::class);
 });
 

--- a/tests/Unit/BillingProvisioningTest.php
+++ b/tests/Unit/BillingProvisioningTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Provisioning\Actions\CreateProvisionedService;
 use Liberu\Billing\Provisioning\Actions\QueueProvisioningOperation;
@@ -19,6 +21,15 @@ it('creates a pending provisioned service through the domain action', function (
     expect($service->state)->toBe(ProvisioningState::Pending)
         ->and($service->team_id)->toBe(10)
         ->and($service->provider)->toBe('test');
+});
+
+it('rejects a provisioned service customer owned by another team', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+
+    expect(fn () => app(CreateProvisionedService::class)->execute([
+        'team_id' => 10, 'customer_id' => $customerId, 'provider' => 'test',
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });
 
 it('runs a queued provider operation and records the external identity', function () {

--- a/tests/Unit/BillingProvisioningTest.php
+++ b/tests/Unit/BillingProvisioningTest.php
@@ -72,3 +72,28 @@ it('records provider failures and schedules a retry', function () {
         ->and($operation->next_poll_at)->not->toBeNull()
         ->and($operation->error)->toBe('Provider unavailable');
 });
+
+it('does not execute a stale operation after it has already completed', function (): void {
+    $registry = app(ProvisioningDriverRegistry::class);
+    $registry->register('already-complete', new class() implements ProvisioningDriver
+    {
+        public function provision(ProvisionedService $service): string
+        {
+            throw new RuntimeException('The completed operation must not call the provider.');
+        }
+
+        public function deprovision(ProvisionedService $service): void {}
+
+        public function poll(ProvisionedService $service): array
+        {
+            return [];
+        }
+    });
+
+    $service = ProvisionedService::query()->create(['team_id' => 10, 'provider' => 'already-complete', 'state' => ProvisioningState::Pending, 'metadata' => []]);
+    $operation = app(QueueProvisioningOperation::class)->execute($service, 'provision');
+    $operation->refresh();
+    $operation->update(['status' => 'completed']);
+
+    expect(app(RunProvisioningOperation::class)->execute($operation)->status)->toBe('completed');
+});

--- a/tests/Unit/BillingProvisioningTest.php
+++ b/tests/Unit/BillingProvisioningTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Provisioning\Actions\CreateProvisionedService;
 use Liberu\Billing\Provisioning\Actions\QueueProvisioningOperation;
+use Liberu\Billing\Provisioning\Actions\ReconcileProvisionedService;
 use Liberu\Billing\Provisioning\Actions\RunProvisioningOperation;
 use Liberu\Billing\Provisioning\Actions\TransitionProvisionedService;
 use Liberu\Billing\Provisioning\Contracts\ProvisioningDriver;
@@ -106,4 +107,15 @@ it('does not transition a service using a stale persisted state', function (): v
 
     expect(fn () => app(TransitionProvisionedService::class)->execute($service, ProvisioningState::Provisioning))
         ->toThrow(InvalidArgumentException::class, 'Invalid provisioning transition from [active] to [provisioning].');
+});
+
+it('reconciles the persisted provisioned service state', function (): void {
+    $service = app(CreateProvisionedService::class)->execute(['team_id' => 10, 'provider' => 'test']);
+    $service->refresh();
+    ProvisionedService::query()->whereKey($service->getKey())->update(['external_id' => 'provider-123']);
+
+    $reconciled = app(ReconcileProvisionedService::class)->execute($service);
+
+    expect($reconciled->external_id)->toBe('provider-123')
+        ->and($reconciled->last_reconciled_at)->not->toBeNull();
 });

--- a/tests/Unit/BillingProvisioningTest.php
+++ b/tests/Unit/BillingProvisioningTest.php
@@ -4,6 +4,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Provisioning\Actions\CreateProvisionedService;
 use Liberu\Billing\Provisioning\Actions\QueueProvisioningOperation;
 use Liberu\Billing\Provisioning\Actions\RunProvisioningOperation;
+use Liberu\Billing\Provisioning\Actions\TransitionProvisionedService;
 use Liberu\Billing\Provisioning\Contracts\ProvisioningDriver;
 use Liberu\Billing\Provisioning\Enums\ProvisioningState;
 use Liberu\Billing\Provisioning\Models\ProvisionedService;
@@ -96,4 +97,13 @@ it('does not execute a stale operation after it has already completed', function
     $operation->update(['status' => 'completed']);
 
     expect(app(RunProvisioningOperation::class)->execute($operation)->status)->toBe('completed');
+});
+
+it('does not transition a service using a stale persisted state', function (): void {
+    $service = app(CreateProvisionedService::class)->execute(['team_id' => 10, 'provider' => 'test']);
+    $service->refresh();
+    ProvisionedService::query()->whereKey($service->getKey())->update(['state' => ProvisioningState::Active->value]);
+
+    expect(fn () => app(TransitionProvisionedService::class)->execute($service, ProvisioningState::Provisioning))
+        ->toThrow(InvalidArgumentException::class, 'Invalid provisioning transition from [active] to [provisioning].');
 });

--- a/tests/Unit/BillingReportingTest.php
+++ b/tests/Unit/BillingReportingTest.php
@@ -40,3 +40,14 @@ it('returns zero for optional metric tables that are not installed', function ()
 
     expect(app(CalculateReportingMetric::class)->execute(10, 'usage', $period, $period)['value'])->toBe(0.0);
 });
+
+it('excludes draft invoices from aging receivables', function (): void {
+    $dueAt = CarbonImmutable::parse('2026-08-20');
+    DB::table('billing_invoices')->insert([
+        ['team_id' => 10, 'status' => 'draft', 'currency' => 'USD', 'total_minor' => 900, 'due_at' => $dueAt, 'created_at' => $dueAt, 'updated_at' => $dueAt],
+        ['team_id' => 10, 'status' => 'finalized', 'currency' => 'USD', 'total_minor' => 1200, 'due_at' => $dueAt, 'created_at' => $dueAt, 'updated_at' => $dueAt],
+    ]);
+
+    expect(app(CalculateReportingMetric::class)->execute(10, 'aging', $dueAt->addDay(), $dueAt->addDay(), 'USD')['value'])
+        ->toBe(1200.0);
+});

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -13,6 +13,7 @@ use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 use Liberu\Billing\Subscriptions\Events\SubscriptionEntitlementsUpdated;
 use Liberu\Billing\Subscriptions\Events\SubscriptionPaused;
 use Liberu\Billing\Subscriptions\Events\SubscriptionPlanChanged;
+use Liberu\Billing\Subscriptions\Models\Subscription;
 
 uses(RefreshDatabase::class);
 
@@ -86,4 +87,15 @@ it('requires an owner and rejects terminal lifecycle mutations', function () {
 
     expect(fn () => app(PauseSubscription::class)->execute($subscription))
         ->toThrow(LogicException::class);
+});
+
+it('rechecks the locked subscription before renewing stale worker state', function () {
+    $subscription = app(ActivateSubscription::class)->execute(['team_id' => 10]);
+    $stale = Subscription::query()->findOrFail($subscription->getKey());
+
+    app(CancelSubscription::class)->execute($subscription);
+
+    expect(fn () => app(RenewSubscription::class)->execute($stale))
+        ->toThrow(LogicException::class, 'Subscription cannot be renewed.')
+        ->and($subscription->refresh()->status)->toBe(SubscriptionStatus::Cancelled);
 });

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
@@ -182,4 +184,13 @@ it('rejects a pricing plan owned by another team', function (): void {
 
     expect(fn () => app(ChangeSubscriptionPlan::class)->execute($subscription, $planId))
         ->toThrow(InvalidArgumentException::class, 'Subscription pricing plan reference is invalid.');
+});
+
+it('rejects a subscription customer owned by another team', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+
+    expect(fn () => app(ActivateSubscription::class)->execute([
+        'team_id' => 10, 'customer_id' => $customerId,
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -54,6 +54,18 @@ it('carries legacy domain protection into the subscription boundary', function (
 
 it('supports plan changes, pause, renewal, and cancellation', function () {
     Event::fake([SubscriptionPaused::class, SubscriptionPlanChanged::class]);
+    DB::table('billing_pricing_plans')->insert([
+        'id' => 4,
+        'team_id' => 10,
+        'name' => 'Changed plan',
+        'pricing_model' => 'flat',
+        'currency' => 'USD',
+        'unit_amount_minor' => 1000,
+        'status' => 'active',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
     $subscription = app(ActivateSubscription::class)->execute(['team_id' => 10]);
     $subscription = app(ChangeSubscriptionPlan::class)->execute($subscription, 4);
     $subscription = app(PauseSubscription::class)->execute($subscription);
@@ -165,4 +177,9 @@ it('rejects a pricing plan owned by another team', function (): void {
         'team_id' => 10,
         'pricing_plan_id' => $planId,
     ]))->toThrow(InvalidArgumentException::class, 'Subscription pricing plan reference is invalid.');
+
+    $subscription = app(ActivateSubscription::class)->execute(['team_id' => 10]);
+
+    expect(fn () => app(ChangeSubscriptionPlan::class)->execute($subscription, $planId))
+        ->toThrow(InvalidArgumentException::class, 'Subscription pricing plan reference is invalid.');
 });

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Subscriptions\Actions\ActivateSubscription;
 use Liberu\Billing\Subscriptions\Actions\CancelSubscription;
 use Liberu\Billing\Subscriptions\Actions\ChangeSubscriptionPlan;
@@ -18,6 +20,18 @@ use Liberu\Billing\Subscriptions\Models\Subscription;
 uses(RefreshDatabase::class);
 
 it('activates a trial subscription with an entitlement', function () {
+    DB::table('billing_pricing_plans')->insert([
+        'id' => 2,
+        'team_id' => 10,
+        'name' => 'Trial plan',
+        'pricing_model' => 'flat',
+        'currency' => 'USD',
+        'unit_amount_minor' => 1000,
+        'status' => 'active',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
     $subscription = app(ActivateSubscription::class)->execute([
         'team_id' => 10,
         'pricing_plan_id' => 2,
@@ -101,6 +115,18 @@ it('rechecks the locked subscription before renewing stale worker state', functi
 });
 
 it('does not change the plan after a subscription becomes terminal', function (): void {
+    DB::table('billing_pricing_plans')->insert([
+        'id' => 1,
+        'team_id' => 10,
+        'name' => 'Current plan',
+        'pricing_model' => 'flat',
+        'currency' => 'USD',
+        'unit_amount_minor' => 1000,
+        'status' => 'active',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
     $subscription = app(ActivateSubscription::class)->execute(['team_id' => 10, 'pricing_plan_id' => 1]);
     $subscription->refresh();
     Subscription::query()->whereKey($subscription->getKey())->update(['status' => SubscriptionStatus::Cancelled->value]);
@@ -116,4 +142,27 @@ it('does not pause a subscription after its persisted state becomes terminal', f
 
     expect(fn () => app(PauseSubscription::class)->execute($subscription))
         ->toThrow(LogicException::class, 'A terminal subscription cannot be paused.');
+});
+
+it('rejects a pricing plan owned by another team', function (): void {
+    if (! Schema::hasTable('billing_pricing_plans')) {
+        $this->markTestSkipped('Pricing tables are not installed.');
+    }
+
+    $planId = DB::table('billing_pricing_plans')->insertGetId([
+        'team_id' => 20,
+        'name' => 'Foreign plan',
+        'pricing_model' => 'flat',
+        'currency' => 'USD',
+        'unit_amount_minor' => 1000,
+        'status' => 'active',
+        'metadata' => json_encode([]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => app(ActivateSubscription::class)->execute([
+        'team_id' => 10,
+        'pricing_plan_id' => $planId,
+    ]))->toThrow(InvalidArgumentException::class, 'Subscription pricing plan reference is invalid.');
 });

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -108,3 +108,12 @@ it('does not change the plan after a subscription becomes terminal', function ()
     expect(fn () => app(ChangeSubscriptionPlan::class)->execute($subscription, 2))
         ->toThrow(LogicException::class, 'A terminal subscription cannot change plans.');
 });
+
+it('does not pause a subscription after its persisted state becomes terminal', function (): void {
+    $subscription = app(ActivateSubscription::class)->execute(['team_id' => 10]);
+    $subscription->refresh();
+    Subscription::query()->whereKey($subscription->getKey())->update(['status' => SubscriptionStatus::Cancelled->value]);
+
+    expect(fn () => app(PauseSubscription::class)->execute($subscription))
+        ->toThrow(LogicException::class, 'A terminal subscription cannot be paused.');
+});

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -99,3 +99,12 @@ it('rechecks the locked subscription before renewing stale worker state', functi
         ->toThrow(LogicException::class, 'Subscription cannot be renewed.')
         ->and($subscription->refresh()->status)->toBe(SubscriptionStatus::Cancelled);
 });
+
+it('does not change the plan after a subscription becomes terminal', function (): void {
+    $subscription = app(ActivateSubscription::class)->execute(['team_id' => 10, 'pricing_plan_id' => 1]);
+    $subscription->refresh();
+    Subscription::query()->whereKey($subscription->getKey())->update(['status' => SubscriptionStatus::Cancelled->value]);
+
+    expect(fn () => app(ChangeSubscriptionPlan::class)->execute($subscription, 2))
+        ->toThrow(LogicException::class, 'A terminal subscription cannot change plans.');
+});

--- a/tests/Unit/BillingUsageTest.php
+++ b/tests/Unit/BillingUsageTest.php
@@ -24,6 +24,27 @@ it('rejects invalid usage events', function () {
         ->toThrow(InvalidArgumentException::class);
 });
 
+it('normalizes meter identifiers and rejects invalid thresholds', function () {
+    $meter = app(DefineMeter::class)->execute([
+        'team_id' => 10,
+        'code' => ' API.Calls ',
+        'name' => ' API calls ',
+        'unit' => ' request ',
+        'currency' => 'usd',
+        'unit_price_minor' => 5,
+        'threshold' => '100.5',
+    ]);
+
+    expect($meter->code)->toBe('api.calls')
+        ->and($meter->name)->toBe('API calls')
+        ->and($meter->unit)->toBe('request')
+        ->and((float) $meter->threshold)->toBe(100.5);
+
+    expect(fn () => app(DefineMeter::class)->execute([
+        'code' => 'requests', 'currency' => 'USD', 'unit_price_minor' => 1, 'threshold' => -1,
+    ]))->toThrow(InvalidArgumentException::class);
+});
+
 it('rates usage progressively across sorted tiers', function () {
     $meter = app(DefineMeter::class)->execute([
         'team_id' => 10,

--- a/tests/Unit/BillingUsageTest.php
+++ b/tests/Unit/BillingUsageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Customer;
+use App\Models\Team;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\Billing\Usage\Actions\CorrectUsage;
 use Liberu\Billing\Usage\Actions\DefineMeter;
@@ -78,4 +80,16 @@ it('does not ingest usage after the persisted meter is deactivated', function ()
 
     expect(fn () => app(IngestUsage::class)->execute($meter, ['event_key' => 'evt-inactive', 'quantity' => 1]))
         ->toThrow(LogicException::class, 'Usage cannot be ingested into an inactive meter.');
+});
+
+it('rejects usage for a customer owned by another team', function (): void {
+    $team = Team::factory()->create(['id' => 20]);
+    $customerId = Customer::factory()->create(['team_id' => $team->getKey()])->getKey();
+    $meter = app(DefineMeter::class)->execute([
+        'team_id' => 10, 'code' => 'requests', 'currency' => 'USD', 'unit_price_minor' => 1,
+    ]);
+
+    expect(fn () => app(IngestUsage::class)->execute($meter, [
+        'customer_id' => $customerId, 'event_key' => 'evt-foreign', 'quantity' => 1,
+    ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
 });

--- a/tests/Unit/BillingUsageTest.php
+++ b/tests/Unit/BillingUsageTest.php
@@ -13,10 +13,14 @@ it('defines meters, deduplicates usage, aggregates, and corrects records', funct
     $meter = app(DefineMeter::class)->execute(['team_id' => 10, 'code' => 'api_calls', 'currency' => 'USD', 'unit_price_minor' => 5]);
     $record = app(IngestUsage::class)->execute($meter, ['event_key' => 'evt-1', 'quantity' => 3]);
     $duplicate = app(IngestUsage::class)->execute($meter, ['event_key' => 'evt-1', 'quantity' => 99]);
-    app(CorrectUsage::class)->execute($record, -1, 'correction-1');
+    $correction = app(CorrectUsage::class)->execute($record, -1, ' correction-1 ');
+    $duplicateCorrection = app(CorrectUsage::class)->execute($record, -99, 'correction-1');
     $aggregate = app(AggregateUsage::class)->execute($meter->getKey());
 
-    expect($duplicate->is($record))->toBeTrue()->and((float) $aggregate->quantity)->toBe(2.0)->and((int) $aggregate->amount_minor)->toBe(10);
+    expect($duplicate->is($record))->toBeTrue()
+        ->and($duplicateCorrection->is($correction))->toBeTrue()
+        ->and((float) $aggregate->quantity)->toBe(2.0)
+        ->and((int) $aggregate->amount_minor)->toBe(10);
 });
 
 it('rejects invalid usage events', function () {

--- a/tests/Unit/BillingUsageTest.php
+++ b/tests/Unit/BillingUsageTest.php
@@ -5,6 +5,7 @@ use Liberu\Billing\Usage\Actions\CorrectUsage;
 use Liberu\Billing\Usage\Actions\DefineMeter;
 use Liberu\Billing\Usage\Actions\IngestUsage;
 use Liberu\Billing\Usage\Actions\RateUsage;
+use Liberu\Billing\Usage\Models\Meter;
 use Liberu\Billing\Usage\Queries\AggregateUsage;
 
 uses(RefreshDatabase::class);
@@ -66,4 +67,15 @@ it('rates usage progressively across sorted tiers', function () {
     $meter->update(['metadata' => ['tiers' => [['up_to' => 0, 'unit_price_minor' => 1]]]]);
     expect(fn () => app(RateUsage::class)->execute($meter, 1))
         ->toThrow(InvalidArgumentException::class);
+});
+
+it('does not ingest usage after the persisted meter is deactivated', function (): void {
+    $meter = app(DefineMeter::class)->execute([
+        'team_id' => 10, 'code' => 'requests', 'currency' => 'USD', 'unit_price_minor' => 1,
+    ]);
+    $meter->refresh();
+    Meter::query()->whereKey($meter->getKey())->update(['active' => false]);
+
+    expect(fn () => app(IngestUsage::class)->execute($meter, ['event_key' => 'evt-inactive', 'quantity' => 1]))
+        ->toThrow(LogicException::class, 'Usage cannot be ingested into an inactive meter.');
 });


### PR DESCRIPTION
## Summary\n- add contract coverage for modular Paddle capture and refunds\n- reject checkout-ready transactions as captured\n- require provider references for captures and refunds\n\n## Verification\n- vendor/bin/pest tests/Unit/BillingPaddleTest.php --compact\n- vendor/bin/pest --compact\n- vendor/bin/pint --test modules/module-billing-paddle/src/PaddleGatewayDriver.php tests/Unit/BillingPaddleTest.php\n- git diff --check\n\nFull suite: 877 passed, 3 skipped, 2415 assertions.