### PR TITLE
Add subscription expiry workflow

### DIFF
--- a/modules/module-billing-subscriptions-api/openapi/v1/billing-subscriptions.yaml
+++ b/modules/module-billing-subscriptions-api/openapi/v1/billing-subscriptions.yaml
@@ -73,6 +73,25 @@ paths:
       responses:
         '200': {$ref: '#/components/responses/ResourceDocument'}
         '401': {$ref: '#/components/responses/Unauthorized'}
+  /api/v1/billing/subscriptions/expire:
+    post:
+      operationId: billing.subscriptions.expire
+      summary: Expire due non-renewing subscriptions
+      security: [{sanctum: []}]
+      parameters: [{$ref: '#/components/parameters/IdempotencyKey'}]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {as_of: {type: string, format: date-time}}
+      responses:
+        '200':
+          description: Number of subscriptions expired.
+          content: {application/json: {schema: {type: object, properties: {data: {type: object, properties: {expired: {type: integer, minimum: 0}}}}}}}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '422': {$ref: '#/components/responses/ValidationError'}
 components:
   parameters:
     IdempotencyKey: {name: Idempotency-Key, in: header, required: false, schema: {type: string, maxLength: 255}}

--- a/modules/module-billing-subscriptions-api/routes/api.php
+++ b/modules/module-billing-subscriptions-api/routes/api.php
@@ -23,4 +23,5 @@ Route::middleware(['api', 'throttle:api', 'auth:sanctum', 'ability:billing.subsc
         Route::post('/{subscription}/cancel', [SubscriptionController::class, 'cancel'])->name('cancel');
         Route::patch('/{subscription}/plan', [SubscriptionController::class, 'changePlan'])->name('plan');
         Route::patch('/{subscription}/entitlements', [SubscriptionController::class, 'entitlements'])->name('entitlements');
+        Route::post('/expire', [SubscriptionController::class, 'expire'])->name('expire');
     });

--- a/modules/module-billing-subscriptions-api/src/Http/Controllers/SubscriptionController.php
+++ b/modules/module-billing-subscriptions-api/src/Http/Controllers/SubscriptionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\Billing\Subscriptions\Api\Http\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -11,6 +12,7 @@ use Illuminate\Support\Facades\Gate;
 use Liberu\Billing\Subscriptions\Actions\ActivateSubscription;
 use Liberu\Billing\Subscriptions\Actions\CancelSubscription;
 use Liberu\Billing\Subscriptions\Actions\ChangeSubscriptionPlan;
+use Liberu\Billing\Subscriptions\Actions\ExpireSubscriptions;
 use Liberu\Billing\Subscriptions\Actions\PauseSubscription;
 use Liberu\Billing\Subscriptions\Actions\RenewSubscription;
 use Liberu\Billing\Subscriptions\Actions\ResumeSubscription;
@@ -98,6 +100,15 @@ final class SubscriptionController extends Controller
         $data = $request->validate(['entitlement_state' => ['required', 'array']]);
 
         return response()->json(['data' => $this->resource($update->execute($subscription, $data['entitlement_state']))]);
+    }
+
+    public function expire(Request $request, ExpireSubscriptions $expire): JsonResponse
+    {
+        Gate::authorize('create', Subscription::class);
+        $data = $request->validate(['as_of' => ['nullable', 'date']]);
+        $teamId = data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id');
+
+        return response()->json(['data' => ['expired' => $expire->execute($teamId === null ? null : (int) $teamId, isset($data['as_of']) ? Carbon::parse($data['as_of']) : null)]]);
     }
 
     private function resource(Subscription $subscription): array

--- a/modules/module-billing-subscriptions-filament/src/Resources/SubscriptionResource.php
+++ b/modules/module-billing-subscriptions-filament/src/Resources/SubscriptionResource.php
@@ -13,6 +13,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Liberu\Billing\Subscriptions\Actions\CancelSubscription;
 use Liberu\Billing\Subscriptions\Actions\ChangeSubscriptionPlan;
+use Liberu\Billing\Subscriptions\Actions\ExpireSubscriptions;
 use Liberu\Billing\Subscriptions\Actions\PauseSubscription;
 use Liberu\Billing\Subscriptions\Actions\RenewSubscription;
 use Liberu\Billing\Subscriptions\Actions\ResumeSubscription;
@@ -65,6 +66,13 @@ final class SubscriptionResource extends Resource
                 ->requiresConfirmation()
                 ->visible(fn (Subscription $record): bool => ! in_array($record->getRawOriginal('status'), ['cancelled', 'expired'], true))
                 ->action(fn (Subscription $record): Subscription => app(CancelSubscription::class)->execute($record)),
+            Action::make('expire')
+                ->label('Expire')
+                ->requiresConfirmation()
+                ->visible(fn (Subscription $record): bool => $record->current_period_ends_at?->isPast() === true && ! $record->auto_renew && ! in_array($record->getRawOriginal('status'), ['cancelled', 'expired'], true))
+                ->action(function (Subscription $record): void {
+                    app(ExpireSubscriptions::class)->execute($record->team_id, now());
+                }),
             Action::make('change_plan')
                 ->label('Change plan')
                 ->form([TextInput::make('pricing_plan_id')->integer()->minValue(1)->required()])

--- a/modules/module-billing-subscriptions-livewire/resources/views/subscription-list.blade.php
+++ b/modules/module-billing-subscriptions-livewire/resources/views/subscription-list.blade.php
@@ -3,6 +3,7 @@
     @if (session()->has('module-billing-subscriptions-message'))
         <p role="status">{{ session('module-billing-subscriptions-message') }}</p>
     @endif
+    <button type="button" wire:click="expireDue">{{ __('Expire due subscriptions') }}</button>
     <button type="button" wire:click="$set('showActivate', true)">{{ __('Activate subscription') }}</button>
     @if ($showActivate)
         <form wire:submit="activate">

--- a/modules/module-billing-subscriptions-livewire/src/Components/SubscriptionList.php
+++ b/modules/module-billing-subscriptions-livewire/src/Components/SubscriptionList.php
@@ -9,6 +9,7 @@ use Illuminate\View\View;
 use Liberu\Billing\Subscriptions\Actions\ActivateSubscription;
 use Liberu\Billing\Subscriptions\Actions\CancelSubscription;
 use Liberu\Billing\Subscriptions\Actions\ChangeSubscriptionPlan;
+use Liberu\Billing\Subscriptions\Actions\ExpireSubscriptions;
 use Liberu\Billing\Subscriptions\Actions\PauseSubscription;
 use Liberu\Billing\Subscriptions\Actions\RenewSubscription;
 use Liberu\Billing\Subscriptions\Actions\ResumeSubscription;
@@ -72,6 +73,14 @@ final class SubscriptionList extends Component
         $change->execute($this->authorizedSubscription($subscriptionId), $this->pricingPlanId);
         $this->reset('pricingPlanId');
         session()->flash('module-billing-subscriptions-message', __('Subscription plan changed.'));
+    }
+
+    public function expireDue(ExpireSubscriptions $expire): void
+    {
+        Gate::authorize('create', Subscription::class);
+        $teamId = data_get(auth()->user(), 'current_team_id') ?? data_get(auth()->user(), 'currentTeam.id');
+        $count = $expire->execute($teamId === null ? null : (int) $teamId);
+        session()->flash('module-billing-subscriptions-message', trans_choice(':count subscription expired.|:count subscriptions expired.', $count, ['count' => $count]));
     }
 
     private function authorizedSubscription(int $subscriptionId): Subscription

--- a/modules/module-billing-subscriptions/CHANGELOG.md
+++ b/modules/module-billing-subscriptions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add an idempotent expiry action for due non-renewing subscriptions and expose it through API, Filament, and Livewire.
+
 ## 0.1.0
 
 - Add the independent Billing Subscriptions lifecycle boundary.

--- a/modules/module-billing-subscriptions/module.json
+++ b/modules/module-billing-subscriptions/module.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.liberu.dev/module/v1.json",
   "name": "module-billing-subscriptions",
   "display_name": "Billing Subscriptions",
-  "description": "Subscription activation, renewal, trials, changes, pauses, cancellation, and entitlements.",
+  "description": "Subscription activation, renewal, trials, changes, pauses, cancellation, expiry, and entitlements.",
   "version": "0.1.0",
   "category": "capability",
   "provider": "Liberu\\Billing\\Subscriptions\\SubscriptionsServiceProvider",
@@ -14,5 +14,5 @@
   "suggests": [],
   "capabilities": ["billing.subscriptions"],
   "default_enabled": true,
-  "features": ["Activation", "Renewal", "Trials", "Plan changes", "Pause", "Cancellation", "Entitlements"]
+  "features": ["Activation", "Renewal", "Trials", "Plan changes", "Pause", "Cancellation", "Expiry", "Entitlements"]
 }

--- a/modules/module-billing-subscriptions/src/Actions/ExpireSubscriptions.php
+++ b/modules/module-billing-subscriptions/src/Actions/ExpireSubscriptions.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Subscriptions\Actions;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\DatabaseManager;
+use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
+use Liberu\Billing\Subscriptions\Events\SubscriptionExpired;
+use Liberu\Billing\Subscriptions\Models\Subscription;
+
+final readonly class ExpireSubscriptions
+{
+    public function __construct(private DatabaseManager $database) {}
+
+    /** @return int Number of subscriptions transitioned to expired. */
+    public function execute(?int $teamId = null, ?CarbonInterface $asOf = null): int
+    {
+        $asOf ??= now();
+        $query = Subscription::query()
+            ->whereIn('status', [SubscriptionStatus::Active, SubscriptionStatus::Trialing])
+            ->where('auto_renew', false)
+            ->whereNotNull('current_period_ends_at')
+            ->where('current_period_ends_at', '<=', $asOf)
+            ->when($teamId !== null, fn ($query) => $query->where('team_id', $teamId));
+        $expired = [];
+
+        $this->database->transaction(function () use ($query, &$expired): void {
+            $query->lockForUpdate()->each(function (Subscription $subscription) use (&$expired): void {
+                $subscription->update([
+                    'status' => SubscriptionStatus::Expired,
+                    'entitlement_state' => array_merge($subscription->entitlement_state ?? [], ['active' => false]),
+                ]);
+                $expired[] = $subscription->refresh();
+            });
+        });
+
+        foreach ($expired as $subscription) {
+            SubscriptionExpired::dispatch($subscription);
+        }
+
+        return count($expired);
+    }
+}

--- a/modules/module-billing-subscriptions/src/Events/SubscriptionExpired.php
+++ b/modules/module-billing-subscriptions/src/Events/SubscriptionExpired.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\Billing\Subscriptions\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Liberu\Billing\Subscriptions\Models\Subscription;
+
+final class SubscriptionExpired
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(public readonly Subscription $subscription) {}
+}

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Customer;
 use App\Models\Team;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
@@ -9,12 +10,14 @@ use Illuminate\Support\Facades\Schema;
 use Liberu\Billing\Subscriptions\Actions\ActivateSubscription;
 use Liberu\Billing\Subscriptions\Actions\CancelSubscription;
 use Liberu\Billing\Subscriptions\Actions\ChangeSubscriptionPlan;
+use Liberu\Billing\Subscriptions\Actions\ExpireSubscriptions;
 use Liberu\Billing\Subscriptions\Actions\PauseSubscription;
 use Liberu\Billing\Subscriptions\Actions\RenewSubscription;
 use Liberu\Billing\Subscriptions\Actions\ResumeSubscription;
 use Liberu\Billing\Subscriptions\Actions\UpdateEntitlementState;
 use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 use Liberu\Billing\Subscriptions\Events\SubscriptionEntitlementsUpdated;
+use Liberu\Billing\Subscriptions\Events\SubscriptionExpired;
 use Liberu\Billing\Subscriptions\Events\SubscriptionPaused;
 use Liberu\Billing\Subscriptions\Events\SubscriptionPlanChanged;
 use Liberu\Billing\Subscriptions\Models\Subscription;
@@ -115,6 +118,21 @@ it('requires an owner and rejects terminal lifecycle mutations', function () {
 
     expect(fn () => app(PauseSubscription::class)->execute($subscription))
         ->toThrow(LogicException::class);
+});
+
+it('expires due non-renewing subscriptions and emits an event', function (): void {
+    Event::fake([SubscriptionExpired::class]);
+    $due = app(ActivateSubscription::class)->execute(['team_id' => 10, 'auto_renew' => false, 'current_period_ends_at' => '2026-08-01 00:00:00']);
+    $future = app(ActivateSubscription::class)->execute(['team_id' => 10, 'auto_renew' => false, 'current_period_ends_at' => '2026-09-01 00:00:00']);
+    $renewing = app(ActivateSubscription::class)->execute(['team_id' => 10, 'auto_renew' => true, 'current_period_ends_at' => '2026-08-01 00:00:00']);
+
+    expect(app(ExpireSubscriptions::class)->execute(10, Carbon::parse('2026-08-15')))->toBe(1)
+        ->and($due->refresh()->status)->toBe(SubscriptionStatus::Expired)
+        ->and($due->entitlement_state['active'])->toBeFalse()
+        ->and($future->refresh()->status)->toBe(SubscriptionStatus::Active)
+        ->and($renewing->refresh()->status)->toBe(SubscriptionStatus::Active);
+    Event::assertDispatched(SubscriptionExpired::class, 1);
+    expect(app(ExpireSubscriptions::class)->execute(10, Carbon::parse('2026-08-15')))->toBe(0);
 });
 
 it('rechecks the locked subscription before renewing stale worker state', function () {


### PR DESCRIPTION
Adds idempotent expiration for due non-renewing subscriptions across the domain, API, Filament, and Livewire surfaces, with a lifecycle event and regression coverage. Full suite: 981 passed, 3 skipped, 2699 assertions.