### PR TITLE
Support configurable subscription periods

### DIFF
--- a/modules/module-billing-subscriptions-api/openapi/v1/billing-subscriptions.yaml
+++ b/modules/module-billing-subscriptions-api/openapi/v1/billing-subscriptions.yaml
@@ -43,6 +43,9 @@ paths:
       summary: Renew a subscription
       security: [{sanctum: []}]
       parameters: [{$ref: '#/components/parameters/SubscriptionId'}, {$ref: '#/components/parameters/IdempotencyKey'}]
+      requestBody:
+        required: false
+        content: {application/json: {schema: {type: object, properties: {period_days: {type: integer, minimum: 1, maximum: 3660}}}}}
       responses:
         '200': {$ref: '#/components/responses/ResourceDocument'}
         '401': {$ref: '#/components/responses/Unauthorized'}
@@ -147,6 +150,7 @@ components:
         starts_at: {type: string, format: date-time}
         trial_ends_at: {anyOf: [{type: string, format: date-time}, {type: 'null'}]}
         current_period_ends_at: {anyOf: [{type: string, format: date-time}, {type: 'null'}]}
+        period_days: {type: integer, minimum: 1}
         cancelled_at: {anyOf: [{type: string, format: date-time}, {type: 'null'}]}
         paused_at: {anyOf: [{type: string, format: date-time}, {type: 'null'}]}
         auto_renew: {type: boolean}
@@ -158,6 +162,7 @@ components:
         pricing_plan_id: {anyOf: [{type: integer, minimum: 1}, {type: 'null'}]}
         trial_days: {type: integer, minimum: 0, maximum: 365, default: 0}
         current_period_ends_at: {anyOf: [{type: string, format: date-time}, {type: 'null'}]}
+        period_days: {type: integer, minimum: 1, default: 30}
         auto_renew: {type: boolean, default: true}
         metadata: {type: object, additionalProperties: true}
     PaginationMeta:

--- a/modules/module-billing-subscriptions-api/src/Http/Controllers/SubscriptionController.php
+++ b/modules/module-billing-subscriptions-api/src/Http/Controllers/SubscriptionController.php
@@ -42,6 +42,7 @@ final class SubscriptionController extends Controller
             'pricing_plan_id' => ['nullable', 'integer', 'min:1'],
             'trial_days' => ['sometimes', 'integer', 'min:0', 'max:365'],
             'current_period_ends_at' => ['nullable', 'date'],
+            'period_days' => ['sometimes', 'integer', 'min:1', 'max:3660'],
             'auto_renew' => ['sometimes', 'boolean'],
             'id_protection' => ['sometimes', 'boolean'],
             'metadata' => ['sometimes', 'array'],
@@ -57,7 +58,9 @@ final class SubscriptionController extends Controller
         $subscription = $this->forCurrentTeam($request, $subscription);
         Gate::authorize('update', $subscription);
 
-        return response()->json(['data' => $this->resource($renew->execute($subscription))]);
+        $data = $request->validate(['period_days' => ['nullable', 'integer', 'min:1', 'max:3660']]);
+
+        return response()->json(['data' => $this->resource($renew->execute($subscription, $data['period_days'] ?? null))]);
     }
 
     public function pause(Request $request, Subscription $subscription, PauseSubscription $pause): JsonResponse
@@ -122,6 +125,7 @@ final class SubscriptionController extends Controller
                 'starts_at' => $subscription->starts_at?->toIso8601String(),
                 'trial_ends_at' => $subscription->trial_ends_at?->toIso8601String(),
                 'current_period_ends_at' => $subscription->current_period_ends_at?->toIso8601String(),
+                'period_days' => $subscription->period_days,
                 'cancelled_at' => $subscription->cancelled_at?->toIso8601String(),
                 'paused_at' => $subscription->paused_at?->toIso8601String(),
             'auto_renew' => $subscription->auto_renew,

--- a/modules/module-billing-subscriptions-filament/src/Resources/SubscriptionResource.php
+++ b/modules/module-billing-subscriptions-filament/src/Resources/SubscriptionResource.php
@@ -36,6 +36,7 @@ final class SubscriptionResource extends Resource
             TextInput::make('customer_id')->integer()->minValue(1),
             TextInput::make('pricing_plan_id')->integer()->minValue(1),
             TextInput::make('trial_days')->integer()->minValue(0)->default(0),
+            TextInput::make('period_days')->integer()->minValue(1)->maxValue(3660)->default(30),
         ]);
     }
 
@@ -51,8 +52,9 @@ final class SubscriptionResource extends Resource
         ])->defaultSort('id', 'desc')->actions([
             Action::make('renew')
                 ->label('Renew')
+                ->form([TextInput::make('period_days')->integer()->minValue(1)->maxValue(3660)])
                 ->visible(fn (Subscription $record): bool => ! in_array($record->getRawOriginal('status'), ['cancelled', 'expired'], true))
-                ->action(fn (Subscription $record): Subscription => app(RenewSubscription::class)->execute($record)),
+                ->action(fn (Subscription $record, array $data): Subscription => app(RenewSubscription::class)->execute($record, isset($data['period_days']) ? (int) $data['period_days'] : null)),
             Action::make('pause')
                 ->label('Pause')
                 ->visible(fn (Subscription $record): bool => ! in_array($record->getRawOriginal('status'), ['paused', 'cancelled', 'expired'], true))

--- a/modules/module-billing-subscriptions-livewire/resources/views/subscription-list.blade.php
+++ b/modules/module-billing-subscriptions-livewire/resources/views/subscription-list.blade.php
@@ -9,6 +9,7 @@
         <form wire:submit="activate">
             <label>{{ __('Pricing plan ID') }} <input type="number" min="0" wire:model="pricingPlanId"></label>
             <label>{{ __('Trial days') }} <input type="number" min="0" max="365" wire:model="trialDays"></label>
+            <label>{{ __('Period days') }} <input type="number" min="1" max="3660" wire:model="periodDays"></label>
             <button type="submit">{{ __('Activate') }}</button>
         </form>
     @endif

--- a/modules/module-billing-subscriptions-livewire/src/Components/SubscriptionList.php
+++ b/modules/module-billing-subscriptions-livewire/src/Components/SubscriptionList.php
@@ -23,6 +23,8 @@ final class SubscriptionList extends Component
 
     public int $trialDays = 0;
 
+    public int $periodDays = 30;
+
     public bool $showActivate = false;
 
     public function activate(ActivateSubscription $activate): void
@@ -31,14 +33,17 @@ final class SubscriptionList extends Component
         $this->validate([
             'pricingPlanId' => ['nullable', 'integer', 'min:0'],
             'trialDays' => ['required', 'integer', 'min:0', 'max:365'],
+            'periodDays' => ['required', 'integer', 'min:1', 'max:3660'],
         ]);
         $teamId = data_get(auth()->user(), 'current_team_id') ?? data_get(auth()->user(), 'currentTeam.id');
         $activate->execute([
             'team_id' => $teamId,
             'pricing_plan_id' => $this->pricingPlanId > 0 ? $this->pricingPlanId : null,
             'trial_days' => $this->trialDays,
+            'period_days' => $this->periodDays,
         ]);
-        $this->reset(['pricingPlanId', 'trialDays', 'showActivate']);
+        $this->reset(['pricingPlanId', 'trialDays', 'periodDays', 'showActivate']);
+        $this->periodDays = 30;
         session()->flash('module-billing-subscriptions-message', __('Subscription activated.'));
     }
 

--- a/modules/module-billing-subscriptions/CHANGELOG.md
+++ b/modules/module-billing-subscriptions/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve configurable subscription period lengths during activation and renewal.
 - Add an idempotent expiry action for due non-renewing subscriptions and expose it through API, Filament, and Livewire.
 
 ## 0.1.0

--- a/modules/module-billing-subscriptions/database/migrations/2026_08_29_210000_add_period_days_to_billing_subscriptions.php
+++ b/modules/module-billing-subscriptions/database/migrations/2026_08_29_210000_add_period_days_to_billing_subscriptions.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('billing_subscriptions', function (Blueprint $table): void {
+            $table->unsignedInteger('period_days')->default(30)->after('current_period_ends_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('billing_subscriptions', function (Blueprint $table): void {
+            $table->dropColumn('period_days');
+        });
+    }
+};

--- a/modules/module-billing-subscriptions/module.json
+++ b/modules/module-billing-subscriptions/module.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.liberu.dev/module/v1.json",
   "name": "module-billing-subscriptions",
   "display_name": "Billing Subscriptions",
-  "description": "Subscription activation, renewal, trials, changes, pauses, cancellation, expiry, and entitlements.",
+  "description": "Subscription activation, renewal, trials, configurable periods, changes, pauses, cancellation, expiry, and entitlements.",
   "version": "0.1.0",
   "category": "capability",
   "provider": "Liberu\\Billing\\Subscriptions\\SubscriptionsServiceProvider",
@@ -14,5 +14,5 @@
   "suggests": [],
   "capabilities": ["billing.subscriptions"],
   "default_enabled": true,
-  "features": ["Activation", "Renewal", "Trials", "Plan changes", "Pause", "Cancellation", "Expiry", "Entitlements"]
+  "features": ["Activation", "Renewal", "Trials", "Configurable periods", "Plan changes", "Pause", "Cancellation", "Expiry", "Entitlements"]
 }

--- a/modules/module-billing-subscriptions/src/Actions/ActivateSubscription.php
+++ b/modules/module-billing-subscriptions/src/Actions/ActivateSubscription.php
@@ -20,6 +20,10 @@ final readonly class ActivateSubscription
     {
         $startsAt = $attributes['starts_at'] ?? now();
         $trialDays = max(0, (int) ($attributes['trial_days'] ?? 0));
+        $periodDays = (int) ($attributes['period_days'] ?? 30);
+        if ($periodDays < 1) {
+            throw new \InvalidArgumentException('Subscription period must be positive.');
+        }
         $trialEndsAt = $trialDays > 0 ? now()->parse($startsAt)->addDays($trialDays) : null;
 
         if (($attributes['team_id'] ?? null) === null && ($attributes['customer_id'] ?? null) === null) {
@@ -42,7 +46,7 @@ final readonly class ActivateSubscription
             throw new \InvalidArgumentException('Subscription pricing plan reference is invalid.');
         }
 
-        $subscription = $this->database->transaction(function () use ($attributes, $startsAt, $trialEndsAt, $trialDays, $pricingPlanId, $customerId): Subscription {
+        $subscription = $this->database->transaction(function () use ($attributes, $startsAt, $trialEndsAt, $trialDays, $periodDays, $pricingPlanId, $customerId): Subscription {
             return Subscription::query()->create([
                 'team_id' => $attributes['team_id'] ?? null,
                 'customer_id' => $customerId,
@@ -51,6 +55,7 @@ final readonly class ActivateSubscription
                 'starts_at' => $startsAt,
                 'trial_ends_at' => $trialEndsAt,
                 'current_period_ends_at' => $attributes['current_period_ends_at'] ?? null,
+                'period_days' => $periodDays,
                 'auto_renew' => $attributes['auto_renew'] ?? true,
                 'id_protection' => $attributes['id_protection'] ?? false,
                 'entitlement_state' => $attributes['entitlement_state'] ?? ['active' => true],

--- a/modules/module-billing-subscriptions/src/Actions/RenewSubscription.php
+++ b/modules/module-billing-subscriptions/src/Actions/RenewSubscription.php
@@ -13,8 +13,9 @@ final readonly class RenewSubscription
 {
     public function __construct(private DatabaseManager $database) {}
 
-    public function execute(Subscription $subscription, int $periodDays = 30): Subscription
+    public function execute(Subscription $subscription, ?int $periodDays = null): Subscription
     {
+        $periodDays ??= (int) ($subscription->period_days ?? 30);
         if ($periodDays < 1) {
             throw new \InvalidArgumentException('Renewal period must be positive.');
         }

--- a/modules/module-billing-subscriptions/src/Models/Subscription.php
+++ b/modules/module-billing-subscriptions/src/Models/Subscription.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 
-#[Fillable(['team_id', 'customer_id', 'pricing_plan_id', 'status', 'starts_at', 'trial_ends_at', 'current_period_ends_at', 'cancelled_at', 'paused_at', 'auto_renew', 'id_protection', 'entitlement_state', 'metadata'])]
+#[Fillable(['team_id', 'customer_id', 'pricing_plan_id', 'status', 'starts_at', 'trial_ends_at', 'current_period_ends_at', 'period_days', 'cancelled_at', 'paused_at', 'auto_renew', 'id_protection', 'entitlement_state', 'metadata'])]
 class Subscription extends Model
 {
     protected $table = 'billing_subscriptions';
@@ -20,6 +20,7 @@ class Subscription extends Model
             'starts_at' => 'datetime',
             'trial_ends_at' => 'datetime',
             'current_period_ends_at' => 'datetime',
+            'period_days' => 'integer',
             'cancelled_at' => 'datetime',
             'paused_at' => 'datetime',
             'auto_renew' => 'boolean',

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -87,6 +87,19 @@ it('supports plan changes, pause, renewal, and cancellation', function () {
         ->and($subscription->auto_renew)->toBeFalse();
 });
 
+it('preserves a configured custom period when renewing', function (): void {
+    $subscription = app(ActivateSubscription::class)->execute([
+        'team_id' => 10,
+        'period_days' => 45,
+        'current_period_ends_at' => '2026-08-01 00:00:00',
+    ]);
+
+    $renewed = app(RenewSubscription::class)->execute($subscription);
+
+    expect($renewed->period_days)->toBe(45)
+        ->and($renewed->current_period_ends_at->toDateString())->toBe('2026-09-15');
+});
+
 it('resumes only paused subscriptions and restores entitlements', function () {
     $subscription = app(ActivateSubscription::class)->execute(['team_id' => 10]);
     $subscription = app(PauseSubscription::class)->execute($subscription);


### PR DESCRIPTION
Preserves configurable subscription billing period lengths across activation and renewal, including API, Filament, and Livewire surfaces. Full suite: 982 passed, 3 skipped, 2701 assertions.