### PR TITLE
Add subscription listing filters

### DIFF
--- a/modules/module-billing-subscriptions-api/CHANGELOG.md
+++ b/modules/module-billing-subscriptions-api/CHANGELOG.md
@@ -4,3 +4,6 @@
 
 - Add subscription collection, activation, pause, renewal, and cancellation endpoints.
 - Add the authenticated resume endpoint for paused subscriptions.
+## Unreleased
+
+- Add customer and status filters to the subscription listing endpoint.

--- a/modules/module-billing-subscriptions-api/openapi/v1/billing-subscriptions.yaml
+++ b/modules/module-billing-subscriptions-api/openapi/v1/billing-subscriptions.yaml
@@ -14,6 +14,8 @@ paths:
       security: [{sanctum: []}]
       parameters:
         - {$ref: '#/components/parameters/PageSize'}
+        - {name: customer_id, in: query, schema: {type: integer, minimum: 1}}
+        - {name: status, in: query, schema: {type: string, enum: [trialing, active, paused, cancelled, expired]}}
       responses:
         '200': {$ref: '#/components/responses/Collection'}
         '401': {$ref: '#/components/responses/Unauthorized'}
@@ -146,6 +148,7 @@ components:
       required: [status, auto_renew, entitlement_state]
       properties:
         status: {type: string, enum: [trialing, active, paused, cancelled, expired]}
+        customer_id: {anyOf: [{type: integer, minimum: 1}, {type: 'null'}]}
         pricing_plan_id: {anyOf: [{type: integer, minimum: 1}, {type: 'null'}]}
         starts_at: {type: string, format: date-time}
         trial_ends_at: {anyOf: [{type: string, format: date-time}, {type: 'null'}]}

--- a/modules/module-billing-subscriptions-api/src/Http/Controllers/SubscriptionController.php
+++ b/modules/module-billing-subscriptions-api/src/Http/Controllers/SubscriptionController.php
@@ -17,6 +17,7 @@ use Liberu\Billing\Subscriptions\Actions\PauseSubscription;
 use Liberu\Billing\Subscriptions\Actions\RenewSubscription;
 use Liberu\Billing\Subscriptions\Actions\ResumeSubscription;
 use Liberu\Billing\Subscriptions\Actions\UpdateEntitlementState;
+use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 use Liberu\Billing\Subscriptions\Models\Subscription;
 use Liberu\Billing\Subscriptions\Queries\ListSubscriptions;
 
@@ -26,7 +27,8 @@ final class SubscriptionController extends Controller
     {
         Gate::authorize('viewAny', Subscription::class);
         $teamId = data_get($request->user(), 'current_team_id') ?? data_get($request->user(), 'currentTeam.id');
-        $subscriptions = $query->execute($teamId === null ? null : (int) $teamId, $request->integer('per_page', 25));
+        $data = $request->validate(['customer_id' => ['nullable', 'integer', 'min:1'], 'status' => ['nullable', 'string', 'in:trialing,active,paused,cancelled,expired']]);
+        $subscriptions = $query->execute($teamId === null ? null : (int) $teamId, $request->integer('per_page', 25), $data['customer_id'] ?? null, isset($data['status']) ? SubscriptionStatus::from($data['status']) : null);
 
         return response()->json([
             'data' => $subscriptions->getCollection()->map(fn (Subscription $subscription): array => $this->resource($subscription))->values(),
@@ -121,6 +123,7 @@ final class SubscriptionController extends Controller
             'type' => 'billing-subscriptions',
             'attributes' => [
                 'status' => $subscription->status->value,
+                'customer_id' => $subscription->customer_id,
                 'pricing_plan_id' => $subscription->pricing_plan_id,
                 'starts_at' => $subscription->starts_at?->toIso8601String(),
                 'trial_ends_at' => $subscription->trial_ends_at?->toIso8601String(),

--- a/modules/module-billing-subscriptions-filament/src/Resources/SubscriptionResource.php
+++ b/modules/module-billing-subscriptions-filament/src/Resources/SubscriptionResource.php
@@ -10,6 +10,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Liberu\Billing\Subscriptions\Actions\CancelSubscription;
 use Liberu\Billing\Subscriptions\Actions\ChangeSubscriptionPlan;
@@ -49,6 +50,9 @@ final class SubscriptionResource extends Resource
             TextColumn::make('starts_at')->dateTime()->sortable(),
             TextColumn::make('current_period_ends_at')->dateTime()->sortable(),
             TextColumn::make('auto_renew')->badge(),
+        ])->filters([
+            SelectFilter::make('status')->options(['trialing' => 'Trialing', 'active' => 'Active', 'paused' => 'Paused', 'cancelled' => 'Cancelled', 'expired' => 'Expired']),
+            SelectFilter::make('customer_id')->label('Customer ID')->options(fn (): array => Subscription::query()->whereNotNull('customer_id')->distinct()->pluck('customer_id', 'customer_id')->mapWithKeys(fn ($id): array => [(string) $id => (string) $id])->all()),
         ])->defaultSort('id', 'desc')->actions([
             Action::make('renew')
                 ->label('Renew')

--- a/modules/module-billing-subscriptions-livewire/resources/views/subscription-list.blade.php
+++ b/modules/module-billing-subscriptions-livewire/resources/views/subscription-list.blade.php
@@ -4,6 +4,8 @@
         <p role="status">{{ session('module-billing-subscriptions-message') }}</p>
     @endif
     <button type="button" wire:click="expireDue">{{ __('Expire due subscriptions') }}</button>
+    <label>{{ __('Customer ID') }} <input type="number" min="0" wire:model.live="filterCustomerId"></label>
+    <label>{{ __('Status') }} <select wire:model.live="filterStatus"><option value="">{{ __('All') }}</option><option value="trialing">{{ __('Trialing') }}</option><option value="active">{{ __('Active') }}</option><option value="paused">{{ __('Paused') }}</option><option value="cancelled">{{ __('Cancelled') }}</option><option value="expired">{{ __('Expired') }}</option></select></label>
     <button type="button" wire:click="$set('showActivate', true)">{{ __('Activate subscription') }}</button>
     @if ($showActivate)
         <form wire:submit="activate">

--- a/modules/module-billing-subscriptions-livewire/src/Components/SubscriptionList.php
+++ b/modules/module-billing-subscriptions-livewire/src/Components/SubscriptionList.php
@@ -13,6 +13,7 @@ use Liberu\Billing\Subscriptions\Actions\ExpireSubscriptions;
 use Liberu\Billing\Subscriptions\Actions\PauseSubscription;
 use Liberu\Billing\Subscriptions\Actions\RenewSubscription;
 use Liberu\Billing\Subscriptions\Actions\ResumeSubscription;
+use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 use Liberu\Billing\Subscriptions\Models\Subscription;
 use Liberu\Billing\Subscriptions\Queries\ListSubscriptions;
 use Livewire\Component;
@@ -26,6 +27,10 @@ final class SubscriptionList extends Component
     public int $periodDays = 30;
 
     public bool $showActivate = false;
+
+    public int $filterCustomerId = 0;
+
+    public string $filterStatus = '';
 
     public function activate(ActivateSubscription $activate): void
     {
@@ -102,7 +107,7 @@ final class SubscriptionList extends Component
         $teamId = data_get(auth()->user(), 'current_team_id') ?? data_get(auth()->user(), 'currentTeam.id');
 
         return view('module-billing-subscriptions-livewire::subscription-list', [
-            'subscriptions' => $query->execute($teamId === null ? null : (int) $teamId),
+            'subscriptions' => $query->execute($teamId === null ? null : (int) $teamId, 25, $this->filterCustomerId > 0 ? $this->filterCustomerId : null, $this->filterStatus !== '' ? SubscriptionStatus::tryFrom($this->filterStatus) : null),
         ]);
     }
 }

--- a/modules/module-billing-subscriptions/CHANGELOG.md
+++ b/modules/module-billing-subscriptions/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserve configurable subscription period lengths during activation and renewal.
+- Add customer and status filters to subscription listings.
 - Add an idempotent expiry action for due non-renewing subscriptions and expose it through API, Filament, and Livewire.
 
 ## 0.1.0

--- a/modules/module-billing-subscriptions/src/Queries/ListSubscriptions.php
+++ b/modules/module-billing-subscriptions/src/Queries/ListSubscriptions.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace Liberu\Billing\Subscriptions\Queries;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Liberu\Billing\Subscriptions\Enums\SubscriptionStatus;
 use Liberu\Billing\Subscriptions\Models\Subscription;
 
 final class ListSubscriptions
 {
-    public function execute(?int $teamId, int $perPage = 25): LengthAwarePaginator
+    public function execute(?int $teamId, int $perPage = 25, ?int $customerId = null, ?SubscriptionStatus $status = null): LengthAwarePaginator
     {
         return Subscription::query()
             ->where('team_id', $teamId ?? -1)
+            ->when($customerId !== null, fn ($query) => $query->where('customer_id', $customerId))
+            ->when($status !== null, fn ($query) => $query->where('status', $status->value))
             ->latest()
             ->paginate(min(max($perPage, 1), 100));
     }

--- a/tests/Unit/BillingSubscriptionsTest.php
+++ b/tests/Unit/BillingSubscriptionsTest.php
@@ -21,6 +21,7 @@ use Liberu\Billing\Subscriptions\Events\SubscriptionExpired;
 use Liberu\Billing\Subscriptions\Events\SubscriptionPaused;
 use Liberu\Billing\Subscriptions\Events\SubscriptionPlanChanged;
 use Liberu\Billing\Subscriptions\Models\Subscription;
+use Liberu\Billing\Subscriptions\Queries\ListSubscriptions;
 
 uses(RefreshDatabase::class);
 
@@ -224,4 +225,20 @@ it('rejects a subscription customer owned by another team', function (): void {
     expect(fn () => app(ActivateSubscription::class)->execute([
         'team_id' => 10, 'customer_id' => $customerId,
     ]))->toThrow(InvalidArgumentException::class, 'Customer reference is invalid.');
+});
+
+it('filters subscription listings by customer and status', function (): void {
+    $team = Team::factory()->create(['id' => 10]);
+    $customer = Customer::factory()->create(['team_id' => $team->getKey()]);
+    $otherCustomer = Customer::factory()->create(['team_id' => $team->getKey()]);
+    app(ActivateSubscription::class)->execute(['team_id' => 10, 'customer_id' => $customer->getKey()]);
+    $paused = app(ActivateSubscription::class)->execute(['team_id' => 10, 'customer_id' => $customer->getKey()]);
+    app(PauseSubscription::class)->execute($paused);
+    app(ActivateSubscription::class)->execute(['team_id' => 10, 'customer_id' => $otherCustomer->getKey()]);
+
+    $result = app(ListSubscriptions::class)->execute(10, 25, $customer->getKey(), SubscriptionStatus::Paused);
+
+    expect($result->total())->toBe(1)
+        ->and($result->first()->customer_id)->toBe($customer->getKey())
+        ->and($result->first()->status)->toBe(SubscriptionStatus::Paused);
 });


### PR DESCRIPTION
Adds customer and status filtering to subscription listings across the shared query, API, Filament, and Livewire surfaces, with regression coverage. Full suite: 983 passed, 3 skipped, 2704 assertions.